### PR TITLE
Add installation docs for all distribution methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,61 @@
 literalizer-cli
-==============
+================
 
 CLI for literalizer - convert data structures to native language literal syntax.
 
 Installation
 ------------
 
+pip
+~~~
+
 Requires Python 3.11+.
 
 .. code-block:: shell
 
-   $ pip install literalizer-cli
+   pip install literalizer-cli
+
+Homebrew (macOS/Linux)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+
+   brew tap adamtheturtle/literalizer-cli
+   brew install literalizer-cli
+
+Pre-built binaries
+~~~~~~~~~~~~~~~~~~
+
+Download the latest binary for your platform from the
+`GitHub releases page <https://github.com/adamtheturtle/literalizer-cli/releases/latest>`__.
+
+Linux:
+
+.. code-block:: shell
+
+   curl -L https://github.com/adamtheturtle/literalizer-cli/releases/download/2026.03.23/literalize-linux -o literalize
+   chmod +x literalize
+
+Docker
+~~~~~~
+
+.. code-block:: shell
+
+   docker run --rm -i ghcr.io/adamtheturtle/literalizer-cli:latest literalize
+
+Nix
+~~~
+
+.. code-block:: shell
+
+   nix run github:adamtheturtle/literalizer-cli/2026.03.23
+
+winget (Windows)
+~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+
+   winget install adamtheturtle.literalizer-cli
 
 Development
 -----------


### PR DESCRIPTION
## Summary
- Adds README installation sections for pip, Homebrew, pre-built binaries, Docker, Nix, and winget
- Includes versioned URLs that the release workflow's find-and-replace steps need (`releases/download/` and `github:adamtheturtle/literalizer-cli/` patterns)
- Fixes the release pipeline failure described in #20's review

## Test plan
- [ ] Verify the `releases/download/X.Y.Z` pattern in README matches the regex in the "Update Linux binary version" release step
- [ ] Verify the `github:adamtheturtle/literalizer-cli/X.Y.Z` pattern matches the regex in the "Update Nix flake version" release step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; main risk is minor drift between the versioned URL patterns in `README.rst` and the release workflow’s find/replace regexes.
> 
> **Overview**
> Expands `README.rst` installation documentation to cover **pip, Homebrew, pre-built binaries, Docker, Nix, and winget**, with copy-pastable commands.
> 
> Adds explicit versioned URL patterns for the Linux binary download (`releases/download/<version>`) and Nix flake (`github:adamtheturtle/literalizer-cli/<version>`) so the release workflow’s automated version bump steps can reliably update the README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebeaeffae320f3340db93831a7d101f5df20c571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->