### PR TITLE
Bump literalizer to 2026.4.13 and add --mode call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- Bump ``literalizer`` to 2026.4.13.
+- Add ``--mode call`` for converting data into function call expressions,
+  with ``--call-function``, ``--call-params``, and ``--per-element`` options.
+
 2026.04.06
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ Usage example
        3,
    ]
 
+   $ echo '[["alice", 30], ["bob", 25]]' | literalize --language python --mode call --call-function create_user --call-params name,age
+   create_user(name="alice", age=30)
+   create_user(name="bob", age=25)
+
 Installation
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,10 @@ Usage example
        3,
    ]
 
+   $ echo '[["alice", 30], ["bob", 25]]' | literalize --language python --mode call --call-function create_user --call-params name,age
+   create_user(name="alice", age=30)
+   create_user(name="bob", age=25)
+
 .. include:: install.rst
 
 Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.4.6",
+    "literalizer==2026.4.13",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -7,7 +7,12 @@ from importlib.metadata import PackageNotFoundError, version
 
 import click
 import literalizer.exceptions
-from literalizer import InputFormat, LiteralizeResult, literalize
+from literalizer import (
+    InputFormat,
+    LiteralizeResult,
+    literalize,
+    literalize_call,
+)
 from literalizer._language import Language, LanguageCls
 from literalizer.languages import ALL_LANGUAGES
 
@@ -241,6 +246,41 @@ def literalize_input(
         raise click.ClickException(message=str(object=exc)) from None
 
 
+def literalize_call_input(
+    *,
+    input_string: str,
+    language: Language,
+    input_format: InputFormat,
+    call_function: str,
+    call_params: tuple[str, ...],
+    per_element: bool,
+) -> LiteralizeResult:
+    """Literalize input as function calls, surfacing errors as CLI errors."""
+    try:
+        return literalize_call(
+            source=input_string,
+            input_format=input_format,
+            language=language,
+            call_function=call_function,
+            call_params=call_params,
+            per_element=per_element,
+        )
+    except literalizer.exceptions.JSONParseError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.JSON5ParseError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.YAMLParseError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.TOMLParseError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.InvalidDictKeyError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.HeterogeneousCoercionError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+    except literalizer.exceptions.NullInCollectionError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
+
+
 @click.command(name="literalize")
 @click.version_option(version=__version__)
 @click.option(
@@ -418,6 +458,28 @@ def literalize_input(
     default=False,
     help="Include language preamble (e.g. package declarations, imports).",
 )
+@click.option(
+    "--mode",
+    default="literal",
+    type=click.Choice(choices=("literal", "call"), case_sensitive=False),
+    help="Output mode: 'literal' for data literals,"
+    " 'call' for function calls.",
+)
+@click.option(
+    "--call-function",
+    default=None,
+    help="Function name for call mode (e.g. 'create_user').",
+)
+@click.option(
+    "--call-params",
+    default=None,
+    help="Comma-separated parameter names for call mode.",
+)
+@click.option(
+    "--per-element/--no-per-element",
+    default=True,
+    help="In call mode, each top-level list element becomes a separate call.",
+)
 def main(
     language: str,
     input_format: str,
@@ -451,6 +513,10 @@ def main(
     default_set_element_type: str | None,
     default_ordered_map_value_type: str | None,
     include_preamble: bool,  # noqa: FBT001
+    mode: str,
+    call_function: str | None,
+    call_params: str | None,
+    per_element: bool,  # noqa: FBT001
 ) -> None:
     """Convert data structures to native language literal syntax."""
     input_string = sys.stdin.read()
@@ -505,16 +571,38 @@ def main(
             lang_kwargs[option_name] = value
 
     lang_instance = lang_cls(indent=indent, **lang_kwargs)
-    result = literalize_input(
-        input_string=input_string,
-        language=lang_instance,
-        input_format=_INPUT_FORMAT_MAP[input_format],
-        pre_indent_level=pre_indent_level,
-        include_delimiters=include_delimiters,
-        variable_name=variable_name,
-        new_variable=new_variable,
-        error_on_coercion=error_on_coercion,
-    )
+
+    if mode == "call":
+        if call_function is None:
+            raise click.UsageError(
+                message="--call-function is required in call mode.",
+            )
+        if call_params is None:
+            raise click.UsageError(
+                message="--call-params is required in call mode.",
+            )
+        parsed_params = tuple(
+            p.strip() for p in call_params.split(sep=",") if p.strip()
+        )
+        result = literalize_call_input(
+            input_string=input_string,
+            language=lang_instance,
+            input_format=_INPUT_FORMAT_MAP[input_format],
+            call_function=call_function,
+            call_params=parsed_params,
+            per_element=per_element,
+        )
+    else:
+        result = literalize_input(
+            input_string=input_string,
+            language=lang_instance,
+            input_format=_INPUT_FORMAT_MAP[input_format],
+            pre_indent_level=pre_indent_level,
+            include_delimiters=include_delimiters,
+            variable_name=variable_name,
+            new_variable=new_variable,
+            error_on_coercion=error_on_coercion,
+        )
     if include_preamble:
         for preamble_line in result.preamble:
             click.echo(message=preamble_line)

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -207,6 +207,17 @@ def _resolve_language_option(
     return enum_cls[upper_value]
 
 
+_LITERALIZER_EXCEPTIONS = (
+    literalizer.exceptions.JSONParseError,
+    literalizer.exceptions.JSON5ParseError,
+    literalizer.exceptions.YAMLParseError,
+    literalizer.exceptions.TOMLParseError,
+    literalizer.exceptions.InvalidDictKeyError,
+    literalizer.exceptions.HeterogeneousCoercionError,
+    literalizer.exceptions.NullInCollectionError,
+)
+
+
 def literalize_input(
     *,
     input_string: str,
@@ -230,19 +241,7 @@ def literalize_input(
             new_variable=new_variable,
             error_on_coercion=error_on_coercion,
         )
-    except literalizer.exceptions.JSONParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.JSON5ParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.YAMLParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.TOMLParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.InvalidDictKeyError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.HeterogeneousCoercionError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.NullInCollectionError as exc:
+    except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
 
 
@@ -265,19 +264,7 @@ def literalize_call_input(
             call_params=call_params,
             per_element=per_element,
         )
-    except literalizer.exceptions.JSONParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.JSON5ParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.YAMLParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.TOMLParseError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.InvalidDictKeyError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.HeterogeneousCoercionError as exc:
-        raise click.ClickException(message=str(object=exc)) from None
-    except literalizer.exceptions.NullInCollectionError as exc:
+    except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
 
 

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -963,3 +963,28 @@ def test_call_mode_javascript() -> None:
     )
     assert result.exit_code == 0
     assert "createUser(" in result.output
+
+
+def test_call_mode_invalid_json() -> None:
+    """Call mode surfaces JSON parse errors as CLI errors."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "foo",
+            "--call-params",
+            "x",
+        ],
+        input="{bad json}\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert "Error:" in result.output

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -260,11 +260,7 @@ def test_error_on_coercion() -> None:
         color=True,
     )
     assert result.exit_code == 1
-    expected = (
-        "Error: Collection contains heterogeneous scalar types "
-        "that would be coerced to strings\n"
-    )
-    assert result.output == expected
+    assert "Collection contains heterogeneous scalar types" in result.output
 
 
 def test_invalid_json_is_shown_cleanly() -> None:
@@ -315,7 +311,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             language=R(empty_dict_key=R.empty_dict_keys.ERROR),
             error_on_coercion=False,
             expected=(
-                "R does not support empty-string dict keys. "
+                'R does not support the dict key "". '
                 "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
                 "as unnamed list elements instead."
             ),
@@ -327,7 +323,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             error_on_coercion=True,
             expected=(
                 "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings"
+                "that would be coerced to strings (found types: int, str)"
             ),
         ),
         ExceptionCase(
@@ -336,8 +332,9 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             language=Java(sequence_format=Java.sequence_formats.LIST),
             error_on_coercion=False,
             expected=(
-                "Java's List.of() does not accept null elements. "
-                "Use sequence_format=ARRAY instead."
+                "Java's List.of() does not accept null elements"
+                " (got 1 items, including null)."
+                " Use sequence_format=ARRAY instead."
             ),
         ),
         ExceptionCase(
@@ -841,3 +838,128 @@ def test_declaration_style_option() -> None:
     )
     assert result.exit_code == 0
     assert "const data" in result.output
+
+
+def test_call_mode() -> None:
+    """--mode call converts data to function call expressions."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "create_user",
+            "--call-params",
+            "name,age",
+        ],
+        input='[["alice", 30], ["bob", 25]]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0
+    expected = (
+        'create_user(name="alice", age=30)\ncreate_user(name="bob", age=25)\n'
+    )
+    assert result.output == expected
+
+
+def test_call_mode_no_per_element() -> None:
+    """--no-per-element passes the whole value as a single argument."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "process",
+            "--call-params",
+            "data",
+            "--no-per-element",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0
+    assert "process(" in result.output
+
+
+def test_call_mode_requires_call_function() -> None:
+    """--mode call without --call-function gives a usage error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-params",
+            "x",
+        ],
+        input="[1]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "--call-function is required" in result.output
+
+
+def test_call_mode_requires_call_params() -> None:
+    """--mode call without --call-params gives a usage error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "foo",
+        ],
+        input="[1]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "--call-params is required" in result.output
+
+
+def test_call_mode_javascript() -> None:
+    """Call mode works with JavaScript (object-style calls)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "javascript",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "createUser",
+            "--call-params",
+            "name,age",
+        ],
+        input='[["alice", 30]]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0
+    assert "createUser(" in result.output

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -4,7 +4,7 @@ Usage: literalize [OPTIONS]
 
 Options:
   --version                       Show the version and exit.
-  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|swift|systemverilog|toml|typescript|visualbasic|yaml|zig]
+  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|forth|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|sml|swift|systemverilog|tcl|toml|typescript|v|visualbasic|wren|yaml|zig]
                                   Target language for output.  [required]
   -f, --input-format [json|json5|yaml|toml]
                                   Input data format.
@@ -23,33 +23,34 @@ Options:
                                   initializer_list, list, seq, sequence, slice,
                                   table, tuple, vec, vector.
   --set-format TEXT               Set format (language-specific). Choices:
-                                  btree_set, frozenset, hash_set, map_set, set,
-                                  sorted_set, tree_set.
+                                  array, btree_set, dict, frozenset, hash_set,
+                                  map_set, set, sorted_set, tree_set.
   --date-format TEXT              Date format (language-specific). Choices: cpp,
                                   csharp, dart, elixir, erlang, fsharp, go,
                                   haskell, iso, java, js, julia, kotlin, lua,
                                   matlab, nim, objc, ocaml, perl, php, python,
-                                  r, raku, ruby, rust, scala, swift, toml, yaml,
-                                  zig.
+                                  r, raku, ruby, rust, scala, sml, swift, toml,
+                                  yaml, zig.
   --datetime-format TEXT          Datetime format (language-specific). Choices:
                                   cpp, csharp, dart, elixir, epoch, erlang,
                                   fsharp, go, haskell, instant, iso, js, julia,
                                   kotlin, lua, matlab, nim, objc, ocaml, perl,
-                                  php, python, r, raku, ruby, rust, scala,
+                                  php, python, r, raku, ruby, rust, scala, sml,
                                   swift, toml, yaml, zig, zoned.
   --bytes-format TEXT             Bytes format (language-specific). Choices:
                                   base64, binary, hex, python.
   --comment-format TEXT           Comment format (language-specific). Choices:
-                                  apostrophe, block, double_dash, double_slash,
-                                  exclamation, hash, line, paren_star, percent,
-                                  semicolon, star_angle.
+                                  apostrophe, backslash, block, double_dash,
+                                  double_slash, exclamation, hash, line, paren,
+                                  paren_star, percent, semicolon, slash,
+                                  star_angle.
   --variable-type-hints TEXT      Variable type hints (language-specific).
                                   Choices: always, auto.
   --declaration-style TEXT        Declaration style (language-specific).
-                                  Choices: assign, auto, block, const, declare,
-                                  def, define, defparameter, dim, final, let,
-                                  let_mut, let_mutable, local, my, short, typed,
-                                  val, var.
+                                  Choices: assign, auto, block, colon, const,
+                                  declare, def, define, defparameter, dim,
+                                  final, let, let_mut, let_mutable, local, mut,
+                                  my, set, short, typed, val, var.
   --dict-entry-style TEXT         Dict entry style (language-specific). Choices:
                                   default, rocket, symbol.
   --dict-format TEXT              Dict format (language-specific). Choices:
@@ -66,13 +67,13 @@ Options:
   --numeric-separator TEXT        Numeric separator (language-specific).
                                   Choices: none, underscore.
   --string-format TEXT            String format (language-specific). Choices:
-                                  double, raw, single, verbatim.
+                                  double, escaped, raw, single, verbatim.
   --trailing-comma TEXT           Trailing comma (language-specific). Choices:
                                   no, yes.
   --empty-dict-key TEXT           Empty dict key handling (language-specific).
                                   Choices: allow, error, positional.
   --line-ending TEXT              Line ending style (language-specific).
-                                  Choices: none, semicolon.
+                                  Choices: newline, none, semicolon.
   --default-dict-key-type TEXT    Default type for dict keys (language-specific,
                                   free-form string).
   --default-dict-value-type TEXT  Default type for dict values (language-
@@ -89,4 +90,12 @@ Options:
   --include-preamble / --no-include-preamble
                                   Include language preamble (e.g. package
                                   declarations, imports).
+  --mode [literal|call]           Output mode: 'literal' for data literals,
+                                  'call' for function calls.
+  --call-function TEXT            Function name for call mode (e.g.
+                                  'create_user').
+  --call-params TEXT              Comma-separated parameter names for call mode.
+  --per-element / --no-per-element
+                                  In call mode, each top-level list element
+                                  becomes a separate call.
   --help                          Show this message and exit.

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.6"
+version = "2026.4.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -521,9 +521,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/23/1d050d860b13e364e55260e41e8b9ad5df9f9f57d115b2b75f6ada3e8f99/literalizer-2026.4.6.tar.gz", hash = "sha256:5aab20a4326cb103568883e4fb9dc88b3df47d1928f16814721e309a569760cd", size = 866886, upload-time = "2026-04-06T08:04:18.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/16/bd230dee5eb2b6b3bb30f9da988d9db4c24ec2f2e8f0840beff8514d7c2d/literalizer-2026.4.13.tar.gz", hash = "sha256:e8eb7475f560bebba7a8dd99c00bc690c3bbea746d9bd30ff61a49ebd670644b", size = 977762, upload-time = "2026-04-13T16:36:33.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/b0/ec2621cb4b5bea1029f3b67e248436b4fc3a2974a57f5e416234ed174910/literalizer-2026.4.6-py3-none-any.whl", hash = "sha256:c21e157298247dc833cf0b19fbd2dfc8168bef989cd11101032161f41ccd9167", size = 257778, upload-time = "2026-04-06T08:04:15.987Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/bef7bc0d2fe278ea0bf4924833b4b855555e4b7f0def1db151b6e709f519/literalizer-2026.4.13-py3-none-any.whl", hash = "sha256:79ee7461e1f6893b5481526c0024bb996e7ff71876bd195f3a5704d5feac1c41", size = 310490, upload-time = "2026-04-13T16:36:31.669Z" },
 ]
 
 [[package]]
@@ -580,12 +580,12 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.4.6" },
+    { name = "literalizer", specifier = "==2026.4.13" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.20.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.8" },
     { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.21.0" },
-    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==0.60.1" },
+    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==0.60.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
@@ -1183,19 +1183,19 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.60.1"
+version = "0.60.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/42/6e/f9acf0192cfe6ab4428d81a33f7246c280750b4ea0aae68b66331baf2946/pyrefly-0.60.1.tar.gz", hash = "sha256:d2206aa58de1890cc8e3fc7114b45a12dd603fba7cd9e7b635731023528c0450", size = 5514085, upload-time = "2026-04-09T20:03:01.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/47/3e237e8a326affc00a67e2719f2e04b50d5a758db509b3812b085169a073/pyrefly-0.60.2.tar.gz", hash = "sha256:d2b7337e5953c755d52ea785cc5e92182723e54c503b0cb4c732dc0b91a20250", size = 5517467, upload-time = "2026-04-10T17:59:36.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/ff/ba18efaa78c76511787dbd03f01aa86504535ea3e573c6360ffe97c6c241/pyrefly-0.60.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:833b26d18a3ba724ba2b36c101ee379925f5853c613bf51168267a32597e01b6", size = 12924976, upload-time = "2026-04-09T20:02:35.976Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6c/9b365c70a5d48f2cd0503633a97dac0e481e68dd5382f0170cf6abbe73d2/pyrefly-0.60.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6430e9e37d39f5a98f403fd3ce012ba38956300e2064eef97b086b78496978d", size = 12434281, upload-time = "2026-04-09T20:02:38.726Z" },
-    { url = "https://files.pythonhosted.org/packages/34/15/a759693e1ddd8a662805ae03a156ee133408b4c6e3adea403b3a5000385d/pyrefly-0.60.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:992d2d9c90e26279154a6d8177901f5c55dbd2278d91d607223979a499644936", size = 35960986, upload-time = "2026-04-09T20:02:41.365Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ad/0d9efc3759456abdaa34981b4d6997a0a70f2e64ce0bae8948179c754b8a/pyrefly-0.60.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81b7f24a3146a40e32e1ae1181263a2e909cdef78ba32cccd5fce3949f126020", size = 38681453, upload-time = "2026-04-09T20:02:44.862Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b7/bed2925d8c779675b4f1f3bfe3eddd580f6fba4d94e7e72b948071b1ccbe/pyrefly-0.60.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37b70aea286db310bae7a01e18bfeedf8c4b5127091e65486a06c46a0f4992d1", size = 36925245, upload-time = "2026-04-09T20:02:48.009Z" },
-    { url = "https://files.pythonhosted.org/packages/24/66/bd3ff3ef548249f96b39103c46f85757da2f6cc6bcc432f44d602db2ad5d/pyrefly-0.60.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f075e019176651c3f444735e505619cc586ddd8785382b47f9fe77178dde2ba3", size = 41464771, upload-time = "2026-04-09T20:02:51.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/9a/58b7808da0943382f29e6845537bbfe00fb7d898784174e3ac20b2011849/pyrefly-0.60.1-py3-none-win32.whl", hash = "sha256:67a48e683ce3b89f6bcf8d13f52e42f1ad3ae3d4b9576e697997f353e2b83e75", size = 11918343, upload-time = "2026-04-09T20:02:54.575Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a4/8175c5e80fc8399608850dc79ad9314d066684120f21eb5411a5047f40dc/pyrefly-0.60.1-py3-none-win_amd64.whl", hash = "sha256:6583cb4faf6e496443b25f6453d49d04df70ba0e00d637e64ac691afe83c5496", size = 12755148, upload-time = "2026-04-09T20:02:56.72Z" },
-    { url = "https://files.pythonhosted.org/packages/00/37/5294059a7b89548bd60e9527c2a8aaf23d0cbe798bd9a0892c42481e11be/pyrefly-0.60.1-py3-none-win_arm64.whl", hash = "sha256:abbac5ac29614a7b481fffbb056625fefdf2cc2ff17f3a6c52f6b90b4d9da94a", size = 12258856, upload-time = "2026-04-09T20:02:59.088Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/a41ea875083319f7a0d428a914c16c3450e408216e3e6895d4e7ab29e4b0/pyrefly-0.60.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f2d40f649a9c2553f275b77c17bf7c1e1191e0d4f27722f8402dfbe34b3d9117", size = 12933115, upload-time = "2026-04-10T17:59:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/13/87/382202982aa0f0c3d38f4f9df11a96b88c35e2fea02062450b2a0a581352/pyrefly-0.60.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98506d3cc7219a336b877c5b2a3f09c973f1f5cdc13f0093eaf50235f27f7102", size = 12444598, upload-time = "2026-04-10T17:59:15.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/9b/86e10efe0e108f7da0b10281cc55ad8cba99aef726569b9bbe8fe106b5d4/pyrefly-0.60.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9f645d3f006d22c474ad8de35981dc7f351b244112b3d80379f8d375eea7bb6", size = 35964581, upload-time = "2026-04-10T17:59:17.73Z" },
+    { url = "https://files.pythonhosted.org/packages/29/da/fb2a8e3cdb89badcd048e4f5388839a6804647cbc6b874cbced598ee0ea0/pyrefly-0.60.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4160d003d9d5142cbcf8d9cb67f9d75689ea20b69f98757202746142e647cab", size = 38681905, upload-time = "2026-04-10T17:59:20.537Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ac/fb86cac2783ab4cc5ec72139543df201eddf37d446b8cfa9c9b951eb9ff5/pyrefly-0.60.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cbd94ff6c361d9ec4d31652f75bbb5eb6d2b9f707e14a3f35320e9b24aac944b", size = 36924191, upload-time = "2026-04-10T17:59:23.209Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/36/4dd6f007b32291ad5490774840345bd2918d6bedaedd6b3430958b768d91/pyrefly-0.60.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd5d4d7d698de2849bea9794584c5c89239428f8c388eb9067ae5c83378d5232", size = 41473073, upload-time = "2026-04-10T17:59:26.353Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1f/84a3d9def891d93580506fe8846edb582af072d092df34881dcca95ecbf5/pyrefly-0.60.2-py3-none-win32.whl", hash = "sha256:01af5ab08d483d50ddce5054b5f7fb2661fed67868c4877f19baed516f66f42a", size = 11929455, upload-time = "2026-04-10T17:59:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1d/5635e077d6ab71fc38672bb197311485aef969432d5498c754d33dc23160/pyrefly-0.60.2-py3-none-win_amd64.whl", hash = "sha256:0aea0568bdb6b31306570003324be9425fa254e0d730b8f028e5809e1cfbc48e", size = 12760970, upload-time = "2026-04-10T17:59:31.628Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3e/011244086ad58ca0eeec8121666b1fadd1b6db078c043f8b4b3977232d33/pyrefly-0.60.2-py3-none-win_arm64.whl", hash = "sha256:0152bc12393a5c8c80324667faa2c74a0f41d84323cc7c94758c50a11edd26c2", size = 12261111, upload-time = "2026-04-10T17:59:33.992Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the `literalizer` dependency from 2026.4.6 to 2026.4.13, which adds 5 new languages (Forth, SML, Tcl, V, Wren) and the `literalize_call` API. Exposes the new call functionality via `--mode call` with `--call-function`, `--call-params`, and `--per-element` CLI options. Updates tests for changed upstream error messages and adds tests for the new call mode. Adds a call mode usage example to the README and docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new output path (`--mode call`) and bumps the core `literalizer` dependency, so behavior and error messages can change across languages/formats.
> 
> **Overview**
> **Adds a new CLI output mode for function calls.** `literalize` now supports `--mode call` with `--call-function`, `--call-params`, and `--per-element` to emit input data as call expressions via upstream `literalize_call`, including usage validation and shared error-wrapping.
> 
> **Updates dependencies, docs, and tests.** Bumps `literalizer` to `2026.4.13` (and refreshes `uv.lock`), updates README/docs examples and generated `--help` text, relaxes assertions for changed upstream error strings, and adds new test coverage for call mode and its error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f7759e31905830ed89efcb4f86ba997a35eb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->