### PR TITLE
Bump literalizer to 2026.4.15 and adopt new API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.4.14",
+    "literalizer==2026.4.15",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -8,8 +8,11 @@ from importlib.metadata import PackageNotFoundError, version
 import click
 import literalizer.exceptions
 from literalizer import (
+    ExistingVariable,
     InputFormat,
     LiteralizeResult,
+    NewVariable,
+    VariableForm,
     literalize,
     literalize_call,
 )
@@ -225,9 +228,9 @@ def literalize_input(
     input_format: InputFormat,
     pre_indent_level: int,
     include_delimiters: bool,
-    variable_name: str | None,
-    new_variable: bool,
+    variable_form: VariableForm | None,
     error_on_coercion: bool,
+    wrap_in_file: bool,
 ) -> LiteralizeResult:
     """Literalize input and surface literalizer errors as CLI errors."""
     try:
@@ -237,9 +240,9 @@ def literalize_input(
             language=language,
             pre_indent_level=pre_indent_level,
             include_delimiters=include_delimiters,
-            variable_name=variable_name,
-            new_variable=new_variable,
+            variable_form=variable_form,
             error_on_coercion=error_on_coercion,
+            wrap_in_file=wrap_in_file,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
@@ -250,9 +253,10 @@ def literalize_call_input(
     input_string: str,
     language: Language,
     input_format: InputFormat,
-    call_function: str,
-    call_params: tuple[str, ...],
+    target_function: str,
+    parameter_names: tuple[str, ...],
     per_element: bool,
+    wrap_in_file: bool,
 ) -> LiteralizeResult:
     """Literalize input as function calls, surfacing errors as CLI errors."""
     try:
@@ -260,9 +264,10 @@ def literalize_call_input(
             source=input_string,
             input_format=input_format,
             language=language,
-            call_function=call_function,
-            call_params=call_params,
+            target_function=target_function,
+            parameter_names=parameter_names,
             per_element=per_element,
+            wrap_in_file=wrap_in_file,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
@@ -309,6 +314,11 @@ def literalize_call_input(
     "--new-variable/--no-new-variable",
     default=True,
     help="Declare a new variable.",
+)
+@click.option(
+    "--wrap-in-file/--no-wrap-in-file",
+    default=False,
+    help="Wrap output as a complete, valid source file.",
 )
 @click.option(
     "--error-on-coercion/--no-error-on-coercion",
@@ -475,6 +485,7 @@ def main(
     include_delimiters: bool,  # noqa: FBT001
     variable_name: str | None,
     new_variable: bool,  # noqa: FBT001
+    wrap_in_file: bool,  # noqa: FBT001
     error_on_coercion: bool,  # noqa: FBT001
     sequence_format: str | None,
     set_format: str | None,
@@ -559,6 +570,13 @@ def main(
 
     lang_instance = lang_cls(indent=indent, **lang_kwargs)
 
+    variable_form: VariableForm | None = None
+    if variable_name is not None:
+        if new_variable:
+            variable_form = NewVariable(name=variable_name)
+        else:
+            variable_form = ExistingVariable(name=variable_name)
+
     if mode == "call":
         if call_function is None:
             raise click.UsageError(
@@ -575,9 +593,10 @@ def main(
             input_string=input_string,
             language=lang_instance,
             input_format=_INPUT_FORMAT_MAP[input_format],
-            call_function=call_function,
-            call_params=parsed_params,
+            target_function=call_function,
+            parameter_names=parsed_params,
             per_element=per_element,
+            wrap_in_file=wrap_in_file,
         )
     else:
         result = literalize_input(
@@ -586,9 +605,9 @@ def main(
             input_format=_INPUT_FORMAT_MAP[input_format],
             pre_indent_level=pre_indent_level,
             include_delimiters=include_delimiters,
-            variable_name=variable_name,
-            new_variable=new_variable,
+            variable_form=variable_form,
             error_on_coercion=error_on_coercion,
+            wrap_in_file=wrap_in_file,
         )
     if include_preamble:
         for preamble_line in result.preamble:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -2,12 +2,12 @@
 
 import textwrap
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from click import ClickException
 from click.testing import CliRunner
 from literalizer import ExistingVariable, InputFormat, NewVariable
-from literalizer._language import Language
 from literalizer.languages import Java, Python, R, Rust
 from pytest_regressions.file_regression import FileRegressionFixture
 
@@ -21,7 +21,7 @@ class ExceptionCase:
 
     input_format: InputFormat
     input_string: str
-    language: Language
+    language: Any
     error_on_coercion: bool
     expected: str
     variable_form: NewVariable | ExistingVariable | None = None

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import pytest
 from click import ClickException
 from click.testing import CliRunner
-from literalizer import InputFormat
+from literalizer import ExistingVariable, InputFormat, NewVariable
 from literalizer._language import Language
 from literalizer.languages import Java, Python, R, Rust
 from pytest_regressions.file_regression import FileRegressionFixture
@@ -24,6 +24,7 @@ class ExceptionCase:
     language: Language
     error_on_coercion: bool
     expected: str
+    variable_form: NewVariable | ExistingVariable | None = None
 
 
 def test_help(file_regression: FileRegressionFixture) -> None:
@@ -380,9 +381,9 @@ def test_literalizer_exceptions_are_wrapped_as_click_exceptions(
             input_format=case.input_format,
             pre_indent_level=0,
             include_delimiters=True,
-            variable_name=None,
-            new_variable=True,
+            variable_form=case.variable_form,
             error_on_coercion=case.error_on_coercion,
+            wrap_in_file=False,
         )
 
     assert exc_info.value.message == case.expected
@@ -988,3 +989,26 @@ def test_call_mode_invalid_json() -> None:
     )
     assert result.exit_code == 1
     assert "Error:" in result.output
+
+
+def test_wrap_in_file() -> None:
+    """--wrap-in-file wraps output as a complete source file."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "go",
+            "-f",
+            "json",
+            "--variable-name",
+            "data",
+            "--wrap-in-file",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0
+    assert "package main" in result.output
+    assert "data" in result.output

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -4,7 +4,7 @@ Usage: literalize [OPTIONS]
 
 Options:
   --version                       Show the version and exit.
-  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|forth|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|sml|swift|systemverilog|tcl|toml|typescript|v|visualbasic|wren|yaml|zig]
+  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|forth|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|nix|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|sml|swift|systemverilog|tcl|toml|typescript|v|visualbasic|wren|yaml|zig]
                                   Target language for output.  [required]
   -f, --input-format [json|json5|yaml|toml]
                                   Input data format.
@@ -16,6 +16,8 @@ Options:
   --variable-name TEXT            Variable name for the output assignment.
   --new-variable / --no-new-variable
                                   Declare a new variable.
+  --wrap-in-file / --no-wrap-in-file
+                                  Wrap output as a complete, valid source file.
   --error-on-coercion / --no-error-on-coercion
                                   Error on heterogeneous type coercion.
   --sequence-format TEXT          Sequence format (language-specific). Choices:
@@ -67,7 +69,8 @@ Options:
   --numeric-separator TEXT        Numeric separator (language-specific).
                                   Choices: none, underscore.
   --string-format TEXT            String format (language-specific). Choices:
-                                  double, escaped, raw, single, verbatim.
+                                  double, escaped, explicit, raw, single,
+                                  verbatim.
   --trailing-comma TEXT           Trailing comma (language-specific). Choices:
                                   no, yes.
   --empty-dict-key TEXT           Empty dict key handling (language-specific).

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.14"
+version = "2026.4.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -521,9 +521,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2b/66afc028588711ee0f2965aa8d09fba2d9ea669850808b6739a77664dde8/literalizer-2026.4.14.tar.gz", hash = "sha256:5b618b97871c7641444887bb3c1ad90a2d59070df8b545541f922caee1c22d4c", size = 995833, upload-time = "2026-04-14T06:04:37.921Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/2e/c0c650eadfb8d73efaa6958c7a0a536590f1e204efa80ae3d6a28afdb25e/literalizer-2026.4.15.tar.gz", hash = "sha256:093bba0a44d2335e47acd126ed1fbdcb14ce23bfa90aa13018b9513de072442e", size = 1007836, upload-time = "2026-04-15T04:27:58.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/46/c3333199db4a923de8526dd9a33d9cf6070ae69666a99520ad9550eb8104/literalizer-2026.4.14-py3-none-any.whl", hash = "sha256:ccf53ee58ba4e497ea12c6bfc8b80513983b5aafec05421ca0415a06ffc4af3c", size = 319723, upload-time = "2026-04-14T06:04:36.306Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2b/8132c735b161b72bc9807f656404bb470b771df3d6737a3436a24f16f0a1/literalizer-2026.4.15-py3-none-any.whl", hash = "sha256:ea6c59a67937c31abbe32de2afb953957e6c8161f6b292db348807b6eaf4324a", size = 329572, upload-time = "2026-04-15T04:27:57.263Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.4.14" },
+    { name = "literalizer", specifier = "==2026.4.15" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.20.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Summary
- Bump literalizer from 2026.4.14 to 2026.4.15
- Adopt the new `variable_form` parameter (`NewVariable`/`ExistingVariable`) replacing the old `variable_name`/`new_variable` parameters on `literalize()`
- Update `literalize_call()` to use renamed parameters (`target_function`, `parameter_names`)
- Add new `--wrap-in-file` CLI option to wrap output as a complete, valid source file
- New languages (e.g. Nix) and string formats (e.g. `explicit`) are now available via the updated dependency

## Test plan
- [x] All 44 tests pass, including new `test_wrap_in_file` test
- [x] Help text regression file regenerated to reflect new options and languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this PR updates a core dependency and rewires CLI-to-library parameter mapping (variable assignment and call-mode), which can subtly change generated output across languages.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.4.15` and updates the CLI integration to match the new upstream API (replacing `variable_name`/`new_variable` with `variable_form`, and renaming call-mode args to `target_function`/`parameter_names`).
> 
> Adds a new `--wrap-in-file` flag that passes through to `literalizer` so output can be emitted as a complete, valid source file; tests and the help-text regression fixture are updated accordingly, and lockfile pins are refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cad729dc2142efa15950852ab002ee189628070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->