### PR TITLE
Make CLI arguments keyword-only to satisfy FBT001

### DIFF
--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -260,8 +260,8 @@ def literalize_call_input(
             source=input_string,
             input_format=input_format,
             language=language,
-            call_function=call_function,
-            call_params=call_params,
+            target_function=call_function,
+            parameter_names=call_params,
             per_element=per_element,
         )
     except _LITERALIZER_EXCEPTIONS as exc:

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -468,14 +468,15 @@ def literalize_call_input(
     help="In call mode, each top-level list element becomes a separate call.",
 )
 def main(
+    *,
     language: str,
     input_format: str,
     pre_indent_level: int,
     indent: str,
-    include_delimiters: bool,  # noqa: FBT001
+    include_delimiters: bool,
     variable_name: str | None,
-    new_variable: bool,  # noqa: FBT001
-    error_on_coercion: bool,  # noqa: FBT001
+    new_variable: bool,
+    error_on_coercion: bool,
     sequence_format: str | None,
     set_format: str | None,
     date_format: str | None,
@@ -499,11 +500,11 @@ def main(
     default_sequence_element_type: str | None,
     default_set_element_type: str | None,
     default_ordered_map_value_type: str | None,
-    include_preamble: bool,  # noqa: FBT001
+    include_preamble: bool,
     mode: str,
     call_function: str | None,
     call_params: str | None,
-    per_element: bool,  # noqa: FBT001
+    per_element: bool,
 ) -> None:
     """Convert data structures to native language literal syntax."""
     input_string = sys.stdin.read()

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -4,7 +4,7 @@ Usage: literalize [OPTIONS]
 
 Options:
   --version                       Show the version and exit.
-  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|forth|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|sml|swift|systemverilog|tcl|toml|typescript|v|visualbasic|wren|yaml|zig]
+  -l, --language [ada|bash|c|clojure|cobol|commonlisp|cpp|crystal|csharp|d|dart|dhall|elixir|elm|erlang|forth|fortran|fsharp|gleam|go|groovy|haskell|hcl|java|javascript|json5|jsonnet|julia|kotlin|lua|matlab|mojo|nim|nix|norg|objectivec|ocaml|occam|odin|perl|php|powershell|purescript|python|r|racket|raku|ruby|rust|scala|scheme|sml|swift|systemverilog|tcl|toml|typescript|v|visualbasic|wren|yaml|zig]
                                   Target language for output.  [required]
   -f, --input-format [json|json5|yaml|toml]
                                   Input data format.


### PR DESCRIPTION
## Summary
- Add `*` to the `main` Click command function signature to make all parameters keyword-only
- Remove 5 `# noqa: FBT001` suppressions that are no longer needed

## Test plan
- [x] `ruff check` passes
- [x] CLI tested manually with `echo '{"key": "value"}' | literalize --language python --input-format json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a CLI function signature/linters cleanup with no logic changes, but it could affect any internal/imported direct calls to `main` that previously passed positional args.
> 
> **Overview**
> Updates the Click `main` command signature to be keyword-only by adding `*`, aligning with Ruff’s boolean-parameter guidance.
> 
> Removes several `# noqa: FBT001` suppressions from boolean parameters since the signature change makes them compliant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940cd2cafcd58bf58113b9e0f85a369722e76013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->