### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates the `deptry` setting key to the non-deprecated name; it may affect which dependency groups `deptry` treats as dev if misconfigured.
> 
> **Overview**
> Updates `pyproject.toml` to replace deptry’s deprecated `pep621_dev_dependency_groups` setting with `optional_dependencies_dev_groups`, keeping the same `dev` and `release` groups to remove deprecation warnings on deptry 0.25+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd29b965b71cf1aeee54d9d47281dbaa2dd1bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->