### PR TITLE
Bump literalizer to 2026.4.21.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,12 @@ Changelog
 Next
 ----
 
-- Bump ``literalizer`` to 2026.4.13.
+- Bump ``literalizer`` to 2026.4.21.1.
+- Add ``--modifier`` (repeatable) for declaration modifiers on new
+  variables in languages that support them (Java, C#, C++).
+- Remove ``--error-on-coercion``: ``literalizer`` now always errors on
+  heterogeneous data that cannot be represented in the target
+  language.
 - Add ``--mode call`` for converting data into function call expressions,
   with ``--call-function``, ``--call-params``, and ``--per-element`` options.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.4.18",
+    "literalizer==2026.4.21.1",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -164,6 +164,52 @@ _LINE_ENDING_HELP = _choices_help(
     option_name="line_ending",
 )
 
+
+def _all_modifier_choices() -> list[str]:
+    """Collect every modifier name across all languages."""
+    members: set[str] = set()
+    for lang_cls in ALL_LANGUAGES:
+        members.update(m.lower() for m in lang_cls.Modifiers.__members__)
+    return sorted(members)
+
+
+_MODIFIER_HELP = (
+    "Declaration modifier (language-specific, repeatable). "
+    f"Choices: {', '.join(_all_modifier_choices())}."
+)
+
+
+def _resolve_modifiers(
+    *,
+    lang_cls: LanguageCls,
+    values: tuple[str, ...],
+) -> frozenset[enum.Enum]:
+    """Resolve CLI modifier strings to the language's Modifiers members."""
+    modifier_enum = lang_cls.Modifiers
+    if not modifier_enum.__members__:
+        lang_name = lang_cls.__name__.lower()
+        raise click.UsageError(
+            message=(
+                f"--modifier is not supported for language '{lang_name}'."
+            ),
+        )
+    resolved: set[enum.Enum] = set()
+    for value in values:
+        upper_value = value.upper()
+        if upper_value not in modifier_enum.__members__:
+            choices = ", ".join(
+                sorted(m.lower() for m in modifier_enum.__members__),
+            )
+            raise click.UsageError(
+                message=(
+                    f"Invalid value '{value}' for --modifier. "
+                    f"Valid choices: {choices}."
+                ),
+            )
+        resolved.add(modifier_enum[upper_value])
+    return frozenset(resolved)
+
+
 # Language options that take a free-form string rather than an enum.
 # Maps CLI option name to a getter for the ``supports_*`` flag.
 _STRING_OPTIONS: dict[
@@ -216,7 +262,7 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.YAMLParseError,
     literalizer.exceptions.TOMLParseError,
     literalizer.exceptions.InvalidDictKeyError,
-    literalizer.exceptions.HeterogeneousCoercionError,
+    literalizer.exceptions.HeterogeneousCollectionError,
     literalizer.exceptions.NullInCollectionError,
 )
 
@@ -229,7 +275,6 @@ def literalize_input(
     pre_indent_level: int,
     include_delimiters: bool,
     variable_form: VariableForm | None,
-    error_on_coercion: bool,
     wrap_in_file: bool,
 ) -> LiteralizeResult:
     """Literalize input and surface literalizer errors as CLI errors."""
@@ -241,7 +286,6 @@ def literalize_input(
             pre_indent_level=pre_indent_level,
             include_delimiters=include_delimiters,
             variable_form=variable_form,
-            error_on_coercion=error_on_coercion,
             wrap_in_file=wrap_in_file,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
@@ -316,14 +360,15 @@ def literalize_call_input(
     help="Declare a new variable.",
 )
 @click.option(
+    "--modifier",
+    "modifiers",
+    multiple=True,
+    help=_MODIFIER_HELP,
+)
+@click.option(
     "--wrap-in-file/--no-wrap-in-file",
     default=False,
     help="Wrap output as a complete, valid source file.",
-)
-@click.option(
-    "--error-on-coercion/--no-error-on-coercion",
-    default=False,
-    help="Error on heterogeneous type coercion.",
 )
 @click.option(
     "--sequence-format",
@@ -486,8 +531,8 @@ def main(
     include_delimiters: bool,
     variable_name: str | None,
     new_variable: bool,
+    modifiers: tuple[str, ...],
     wrap_in_file: bool,
-    error_on_coercion: bool,
     sequence_format: str | None,
     set_format: str | None,
     date_format: str | None,
@@ -574,9 +619,27 @@ def main(
     variable_form: VariableForm | None = None
     if variable_name is not None:
         if new_variable:
-            variable_form = NewVariable(name=variable_name)
+            resolved_modifiers: frozenset[enum.Enum] = (
+                _resolve_modifiers(lang_cls=lang_cls, values=modifiers)
+                if modifiers
+                else frozenset()
+            )
+            variable_form = NewVariable(
+                name=variable_name,
+                modifiers=resolved_modifiers,
+            )
         else:
+            if modifiers:
+                raise click.UsageError(
+                    message=(
+                        "--modifier cannot be used with --no-new-variable."
+                    ),
+                )
             variable_form = ExistingVariable(name=variable_name)
+    elif modifiers:
+        raise click.UsageError(
+            message="--modifier requires --variable-name.",
+        )
 
     if mode == "call":
         if call_function is None:
@@ -607,7 +670,6 @@ def main(
             pre_indent_level=pre_indent_level,
             include_delimiters=include_delimiters,
             variable_form=variable_form,
-            error_on_coercion=error_on_coercion,
             wrap_in_file=wrap_in_file,
         )
     if include_preamble:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -22,7 +22,6 @@ class ExceptionCase:
     input_format: InputFormat
     input_string: str
     language: Any
-    error_on_coercion: bool
     expected: str
     variable_form: NewVariable | ExistingVariable | None = None
 
@@ -244,8 +243,8 @@ def test_no_new_variable() -> None:
     assert result.output == expected
 
 
-def test_error_on_coercion() -> None:
-    """--error-on-coercion raises error for heterogeneous types."""
+def test_heterogeneous_collection_error() -> None:
+    """Heterogeneous scalar collections surface as CLI errors."""
     runner = CliRunner()
     result = runner.invoke(
         cli=main,
@@ -254,14 +253,13 @@ def test_error_on_coercion() -> None:
             "rust",
             "-f",
             "json",
-            "--error-on-coercion",
         ],
         input='[1, "a"]\n',
         catch_exceptions=False,
         color=True,
     )
     assert result.exit_code == 1
-    assert "Collection contains heterogeneous scalar types" in result.output
+    assert "heterogeneous" in result.output.lower()
 
 
 def test_invalid_json_is_shown_cleanly() -> None:
@@ -310,7 +308,6 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             input_format=InputFormat.JSON,
             input_string='{"": 1}\n',
             language=R(empty_dict_key=R.empty_dict_keys.ERROR),
-            error_on_coercion=False,
             expected=(
                 'R does not support the dict key "". '
                 "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
@@ -321,17 +318,16 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             input_format=InputFormat.JSON,
             input_string='[1, "a"]\n',
             language=Rust(sequence_format=Rust.sequence_formats.VEC),
-            error_on_coercion=True,
             expected=(
-                "Collection contains heterogeneous scalar types "
-                "that would be coerced to strings (found types: int, str)"
+                "Collection contains heterogeneous scalar types that "
+                "cannot be represented in the target language "
+                "(found types: int, str)"
             ),
         ),
         ExceptionCase(
             input_format=InputFormat.JSON,
             input_string="[null]\n",
             language=Java(sequence_format=Java.sequence_formats.LIST),
-            error_on_coercion=False,
             expected=(
                 "Java's List.of() does not accept null elements"
                 " (got 1 items, including null)."
@@ -342,14 +338,12 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
             input_format=InputFormat.JSON,
             input_string='{"a": }\n',
             language=Python(),
-            error_on_coercion=False,
             expected="Invalid JSON: Expecting value at line 1 column 7",
         ),
         ExceptionCase(
             input_format=InputFormat.YAML,
             input_string="a: [1\n",
             language=Python(),
-            error_on_coercion=False,
             expected=(
                 "Invalid YAML: while parsing a flow sequence\n"
                 '  in "<unicode string>", line 1, column 4:\n'
@@ -364,7 +358,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
     ],
     ids=(
         "empty_dict_key",
-        "heterogeneous_coercion",
+        "heterogeneous_collection",
         "null_in_collection",
         "json_parse",
         "yaml_parse",
@@ -382,7 +376,6 @@ def test_literalizer_exceptions_are_wrapped_as_click_exceptions(
             pre_indent_level=0,
             include_delimiters=True,
             variable_form=case.variable_form,
-            error_on_coercion=case.error_on_coercion,
             wrap_in_file=False,
         )
 
@@ -816,6 +809,148 @@ def test_trailing_comma_option() -> None:
     """
     )
     assert result.output == expected
+
+
+def test_modifier_option_java() -> None:
+    """--modifier adds declaration modifiers in supported languages."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "java",
+            "-f",
+            "json",
+            "--variable-name",
+            "DATA",
+            "--modifier",
+            "public",
+            "--modifier",
+            "static",
+            "--modifier",
+            "final",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("public static final ")
+    assert "DATA" in result.output
+
+
+def test_modifier_option_case_insensitive() -> None:
+    """--modifier accepts values case-insensitively."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "csharp",
+            "-f",
+            "json",
+            "--variable-name",
+            "Data",
+            "--modifier",
+            "READONLY",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    assert "readonly " in result.output
+
+
+def test_modifier_unsupported_for_language() -> None:
+    """Error when --modifier is used with a language without modifiers."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--variable-name",
+            "data",
+            "--modifier",
+            "final",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "--modifier is not supported for language 'python'" in result.output
+
+
+def test_modifier_invalid_value() -> None:
+    """Error when --modifier is given a value the language does not support."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "java",
+            "-f",
+            "json",
+            "--variable-name",
+            "data",
+            "--modifier",
+            "readonly",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "Invalid value 'readonly' for --modifier" in result.output
+
+
+def test_modifier_requires_variable_name() -> None:
+    """--modifier without --variable-name is a usage error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "java",
+            "-f",
+            "json",
+            "--modifier",
+            "final",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "--modifier requires --variable-name" in result.output
+
+
+def test_modifier_conflicts_with_no_new_variable() -> None:
+    """--modifier with --no-new-variable is a usage error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "java",
+            "-f",
+            "json",
+            "--variable-name",
+            "data",
+            "--no-new-variable",
+            "--modifier",
+            "final",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    assert "--modifier cannot be used with --no-new-variable" in result.output
 
 
 def test_declaration_style_option() -> None:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -259,7 +259,12 @@ def test_heterogeneous_collection_error() -> None:
         color=True,
     )
     assert result.exit_code == 1
-    assert "heterogeneous" in result.output.lower()
+    expected = (
+        "Error: Collection contains heterogeneous scalar types that "
+        "cannot be represented in the target language "
+        "(found types: int, str)\n"
+    )
+    assert result.output == expected
 
 
 def test_invalid_json_is_shown_cleanly() -> None:
@@ -835,8 +840,14 @@ def test_modifier_option_java() -> None:
         color=True,
     )
     assert result.exit_code == 0, result.output
-    assert result.output.startswith("public static final ")
-    assert "DATA" in result.output
+    expected = textwrap.dedent(
+        text="""\
+        public static final Map<String, Integer> DATA = Map.ofEntries(
+            Map.entry("a", 1)
+        );
+    """
+    )
+    assert result.output == expected
 
 
 def test_modifier_option_case_insensitive() -> None:
@@ -859,7 +870,14 @@ def test_modifier_option_case_insensitive() -> None:
         color=True,
     )
     assert result.exit_code == 0, result.output
-    assert "readonly " in result.output
+    expected = textwrap.dedent(
+        text="""\
+        readonly Dictionary<string, int> Data = new Dictionary<string, int> {
+            ["a"] = 1
+        };
+    """
+    )
+    assert result.output == expected
 
 
 def test_modifier_unsupported_for_language() -> None:
@@ -881,8 +899,14 @@ def test_modifier_unsupported_for_language() -> None:
         catch_exceptions=False,
         color=True,
     )
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: --modifier is not supported for language 'python'.\n"
+    )
     assert result.exit_code != 0
-    assert "--modifier is not supported for language 'python'" in result.output
+    assert result.output == expected
 
 
 def test_modifier_invalid_value() -> None:
@@ -904,8 +928,15 @@ def test_modifier_invalid_value() -> None:
         catch_exceptions=False,
         color=True,
     )
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: Invalid value 'readonly' for --modifier. "
+        "Valid choices: final, private, protected, public, static.\n"
+    )
     assert result.exit_code != 0
-    assert "Invalid value 'readonly' for --modifier" in result.output
+    assert result.output == expected
 
 
 def test_modifier_requires_variable_name() -> None:
@@ -925,8 +956,14 @@ def test_modifier_requires_variable_name() -> None:
         catch_exceptions=False,
         color=True,
     )
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: --modifier requires --variable-name.\n"
+    )
     assert result.exit_code != 0
-    assert "--modifier requires --variable-name" in result.output
+    assert result.output == expected
 
 
 def test_modifier_conflicts_with_no_new_variable() -> None:
@@ -949,8 +986,14 @@ def test_modifier_conflicts_with_no_new_variable() -> None:
         catch_exceptions=False,
         color=True,
     )
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: --modifier cannot be used with --no-new-variable.\n"
+    )
     assert result.exit_code != 0
-    assert "--modifier cannot be used with --no-new-variable" in result.output
+    assert result.output == expected
 
 
 def test_declaration_style_option() -> None:

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -16,10 +16,11 @@ Options:
   --variable-name TEXT            Variable name for the output assignment.
   --new-variable / --no-new-variable
                                   Declare a new variable.
+  --modifier TEXT                 Declaration modifier (language-specific,
+                                  repeatable). Choices: const, final, private,
+                                  protected, public, readonly, static.
   --wrap-in-file / --no-wrap-in-file
                                   Wrap output as a complete, valid source file.
-  --error-on-coercion / --no-error-on-coercion
-                                  Error on heterogeneous type coercion.
   --sequence-format TEXT          Sequence format (language-specific). Choices:
                                   array, cell_array, dynamic_array,
                                   initializer_list, list, seq, sequence, slice,
@@ -52,7 +53,7 @@ Options:
                                   Choices: assign, auto, block, colon, const,
                                   declare, def, define, defparameter, dim,
                                   final, let, let_mut, let_mutable, local, mut,
-                                  my, set, short, typed, val, var.
+                                  my, set, short, static, typed, val, var.
   --dict-entry-style TEXT         Dict entry style (language-specific). Choices:
                                   default, rocket, symbol.
   --dict-format TEXT              Dict format (language-specific). Choices:

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.18"
+version = "2026.4.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -521,9 +521,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/7b/c1c167eba641c93ee3c15bffffa656f821d80f1524490f4eb65554455a5d/literalizer-2026.4.18.tar.gz", hash = "sha256:02609b6d4a646efe9a6e78a176e1e034f966a600d4af79bd2417fa7759ededd4", size = 1066739, upload-time = "2026-04-18T17:06:49.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/99/e8364ae2a5b4492a3fa2bfa5a37ce6dc2b8f124ccfd2f13537584191a867/literalizer-2026.4.21.1.tar.gz", hash = "sha256:41e4aa430fb79b86fc1cc0a5e9c26d6370c4186674ed73d1d1ca152306e497a6", size = 1118597, upload-time = "2026-04-21T05:46:35.483Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/2a/d79db3b50ff59315e5f177709b365d8535b21169ac9fe2c7c1148be392d1/literalizer-2026.4.18-py3-none-any.whl", hash = "sha256:e86626c258ecbf8adce758c8fb117f822886874cb72b8d0f6445072ad197285b", size = 335038, upload-time = "2026-04-18T17:06:47.892Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d8/38ec6b5529e740d41dd9cd749d000de8cc5441d9f5abd640b820cd147815/literalizer-2026.4.21.1-py3-none-any.whl", hash = "sha256:ec7754e51e907ecc9aef6dbabdedc40fc8d8363118a1c4263bb978bf169f755a", size = 369164, upload-time = "2026-04-21T05:46:33.722Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.4.18" },
+    { name = "literalizer", specifier = "==2026.4.21.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.20.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Summary
- Bump `literalizer` pin from 2026.4.18 to 2026.4.21.1.
- Drop `--error-on-coercion`: literalizer now always errors on unrepresentable heterogeneous data. Wrap the new `HeterogeneousCollectionError` base in place of `HeterogeneousCoercionError`.
- Add repeatable `--modifier` option backed by the new `NewVariable.modifiers` feature (Java, C#, C++); errors when used with an unsupported language, with `--no-new-variable`, or without `--variable-name`.

## Test plan
- [x] `uv run pytest` (50 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run mypy`, `uv run pyright`, `uv run ty check`, `uv run pyrefly check`
- [x] Smoke: `echo '{"a":1}' | literalize -l java --variable-name DATA --modifier public --modifier static --modifier final`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI surface area and variable-declaration output via new `--modifier` handling and updated error behavior; risk is mostly around CLI compatibility/regressions rather than security or data integrity.
> 
> **Overview**
> Updates the pinned `literalizer` dependency to `2026.4.21.1` and aligns the CLI with upstream behavior by **removing `--error-on-coercion`** and always surfacing heterogeneous-collection failures (now wrapping `HeterogeneousCollectionError`).
> 
> Adds a repeatable `--modifier` option that maps to `NewVariable(modifiers=...)` for languages that support declaration modifiers, with explicit usage errors for unsupported languages, missing `--variable-name`, invalid modifier values, or use alongside `--no-new-variable`; help text and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bee3c942824d025009cab55b74f78ee264eb074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->