### PR TITLE
Bump literalizer to 2026.4.21.4 and adopt API changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,16 @@ Changelog
 Next
 ----
 
-- Bump ``literalizer`` to 2026.4.21.1.
+- Bump ``literalizer`` to 2026.4.21.4.
+- Add ``--heterogeneous-strategy`` to pick between per-language
+  strategies for collections with mixed scalar types (e.g. Rust's
+  ``tagged_enum``, which emits a generated tagged ``enum`` preamble
+  and wraps each value at the call site).
+- Surface ``literalize_call`` errors as clean CLI messages rather
+  than tracebacks: parameter-count mismatches, languages with no call
+  syntax (YAML, TOML, JSON5, Norg), and languages whose call rendering
+  is not yet implemented all now exit with a descriptive ``Error:``
+  line.
 - Add ``--modifier`` (repeatable) for declaration modifiers on new
   variables in languages that support them (Java, C#, C++).
 - Remove ``--error-on-coercion``: ``literalizer`` now always errors on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.4.21.1",
+    "literalizer==2026.4.21.4",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -59,6 +59,7 @@ _OPTION_TO_ENUM: dict[str, Callable[[LanguageCls], type[enum.Enum]]] = {
     "trailing_comma": lambda cls: cls.TrailingCommas,
     "empty_dict_key": lambda cls: cls.EmptyDictKey,
     "line_ending": lambda cls: cls.LineEndings,
+    "heterogeneous_strategy": lambda cls: cls.HeterogeneousStrategies,
 }
 
 
@@ -163,6 +164,10 @@ _LINE_ENDING_HELP = _choices_help(
     label="Line ending style",
     option_name="line_ending",
 )
+_HETEROGENEOUS_STRATEGY_HELP = _choices_help(
+    label="Heterogeneous-collection strategy",
+    option_name="heterogeneous_strategy",
+)
 
 
 def _all_modifier_choices() -> list[str]:
@@ -264,6 +269,12 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.InvalidDictKeyError,
     literalizer.exceptions.HeterogeneousCollectionError,
     literalizer.exceptions.NullInCollectionError,
+    literalizer.exceptions.PerElementNotListError,
+    literalizer.exceptions.ParameterCountMismatchError,
+    literalizer.exceptions.CallsNotSupportedByLanguageError,
+    literalizer.exceptions.CallsNotSupportedByToolError,
+    literalizer.exceptions.IncompatibleFormatsError,
+    literalizer.exceptions.UnrepresentableIntegerError,
 )
 
 
@@ -461,6 +472,11 @@ def literalize_call_input(
     help=_LINE_ENDING_HELP,
 )
 @click.option(
+    "--heterogeneous-strategy",
+    default=None,
+    help=_HETEROGENEOUS_STRATEGY_HELP,
+)
+@click.option(
     "--default-dict-key-type",
     default=None,
     help="Default type for dict keys (language-specific, free-form string).",
@@ -551,6 +567,7 @@ def main(
     trailing_comma: str | None,
     empty_dict_key: str | None,
     line_ending: str | None,
+    heterogeneous_strategy: str | None,
     default_dict_key_type: str | None,
     default_dict_value_type: str | None,
     default_sequence_element_type: str | None,
@@ -586,6 +603,7 @@ def main(
         "trailing_comma": trailing_comma,
         "empty_dict_key": empty_dict_key,
         "line_ending": line_ending,
+        "heterogeneous_strategy": heterogeneous_strategy,
     }
     for option_name, value in cli_language_options.items():
         if value is not None:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -1169,6 +1169,171 @@ def test_call_mode_invalid_json() -> None:
     assert "Error:" in result.output
 
 
+def test_pre_indent_level_with_variable_name() -> None:
+    """Pre-indent level uniformly offsets every line of a declaration."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--pre-indent-level",
+            "1",
+            "--variable-name",
+            "data",
+        ],
+        input='{"a": 1, "b": [2, 3]}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    expected = '    data = {\n        "a": 1,\n        "b": (2, 3),\n    }\n'
+    assert result.output == expected
+
+
+def test_heterogeneous_strategy_rust_tagged_enum() -> None:
+    """--heterogeneous-strategy tagged_enum wraps Rust heterogeneous values."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "rust",
+            "-f",
+            "json",
+            "--heterogeneous-strategy",
+            "tagged_enum",
+            "--variable-name",
+            "data",
+            "--include-preamble",
+        ],
+        input='[1, "a"]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    expected = (
+        "enum Value {\n"
+        "    I32(i32),\n"
+        "    Str(&'static str),\n"
+        "}\n"
+        "let data = vec![\n"
+        "    Value::I32(1),\n"
+        '    Value::Str("a"),\n'
+        "];\n"
+    )
+    assert result.output == expected
+
+
+def test_heterogeneous_strategy_invalid_for_language() -> None:
+    """Error when the strategy is not valid for the language."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--heterogeneous-strategy",
+            "tagged_enum",
+        ],
+        input='[1, "a"]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code != 0
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: Invalid value 'tagged_enum' for "
+        "--heterogeneous-strategy. Valid choices: error.\n"
+    )
+    assert result.output == expected
+
+
+def test_call_mode_language_has_no_call_syntax() -> None:
+    """Languages with no call syntax raise a clean CLI error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "yaml",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "foo",
+            "--call-params",
+            "x",
+        ],
+        input="[[1]]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert result.output == "Error: Yaml has no function call syntax\n"
+
+
+def test_call_mode_not_implemented_for_language() -> None:
+    """Languages without call rendering implemented raise a clean error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "cobol",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "foo",
+            "--call-params",
+            "x",
+        ],
+        input="[[1]]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = (
+        "Error: literalizer does not support "
+        "function call rendering for Cobol\n"
+    )
+    assert result.output == expected
+
+
+def test_call_mode_parameter_count_mismatch() -> None:
+    """Mismatched --call-params count raises a clean CLI error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "foo",
+            "--call-params",
+            "x,y,z",
+        ],
+        input="[[1]]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert result.output == "Error: Expected 3 parameters but got 1 values\n"
+
+
 def test_wrap_in_file() -> None:
     """--wrap-in-file wraps output as a complete source file."""
     runner = CliRunner()

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -78,6 +78,8 @@ Options:
                                   Choices: allow, error, positional.
   --line-ending TEXT              Line ending style (language-specific).
                                   Choices: newline, none, semicolon.
+  --heterogeneous-strategy TEXT   Heterogeneous-collection strategy (language-
+                                  specific). Choices: error, tagged_enum.
   --default-dict-key-type TEXT    Default type for dict keys (language-specific,
                                   free-form string).
   --default-dict-value-type TEXT  Default type for dict values (language-

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.21.1"
+version = "2026.4.21.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -521,9 +521,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/99/e8364ae2a5b4492a3fa2bfa5a37ce6dc2b8f124ccfd2f13537584191a867/literalizer-2026.4.21.1.tar.gz", hash = "sha256:41e4aa430fb79b86fc1cc0a5e9c26d6370c4186674ed73d1d1ca152306e497a6", size = 1118597, upload-time = "2026-04-21T05:46:35.483Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a6/e1623791663217ec6107792e5bb9bcd145f7d5fb9bf4284239f4afcdfac4/literalizer-2026.4.21.4.tar.gz", hash = "sha256:d5628fdc71f64b71b3d0b22248dd784d5a139a77ca49062a4c16fe9614720199", size = 1142649, upload-time = "2026-04-21T12:18:33.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/d8/38ec6b5529e740d41dd9cd749d000de8cc5441d9f5abd640b820cd147815/literalizer-2026.4.21.1-py3-none-any.whl", hash = "sha256:ec7754e51e907ecc9aef6dbabdedc40fc8d8363118a1c4263bb978bf169f755a", size = 369164, upload-time = "2026-04-21T05:46:33.722Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/38/cd275eac284a3ab00a9c505597d7ac55556d320cdfa4d7815b796894fd96/literalizer-2026.4.21.4-py3-none-any.whl", hash = "sha256:e6755d1f1b0b2081fc94891436b9fa85b1de55aafc1e75e8b5c79a0f8f1d06be", size = 386311, upload-time = "2026-04-21T12:18:31.569Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.4.21.1" },
+    { name = "literalizer", specifier = "==2026.4.21.4" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.20.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Summary
- Bump `literalizer` 2026.4.21.1 → 2026.4.21.4.
- Add `--heterogeneous-strategy`, driven by the new per-language `HeterogeneousStrategies` enum (enables Rust's `tagged_enum` output with auto-generated preamble).
- Surface the new `literalize_call` exceptions (`ParameterCountMismatchError`, `CallsNotSupportedByLanguageError`, `CallsNotSupportedByToolError`) plus `PerElementNotListError`, `IncompatibleFormatsError`, and `UnrepresentableIntegerError` as clean CLI errors.
- Add tests for the new strategy, each new error path, and the 2026.4.21.4 `pre_indent_level` + variable-name fix.

## Test plan
- [x] `uv run pytest tests/`
- [x] `uv run ruff check src tests` / `ruff format --check`
- [x] `uv run mypy src tests`
- [x] `uv run ty check src tests`
- [x] `uv run pyright src tests`
- [x] `uv run pyrefly check src tests`
- [x] `uv run deptry src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a dependency bump plus new CLI surface area (`--heterogeneous-strategy`) and expanded exception handling that can change error outputs/exit behavior in call mode.
> 
> **Overview**
> Updates dependency to `literalizer==2026.4.21.4` and refreshes the lockfile/changelog accordingly.
> 
> Adds a new `--heterogeneous-strategy` language option (wired to per-language `HeterogeneousStrategies`) to control how mixed-type scalar collections are rendered, including Rust `tagged_enum` output.
> 
> Expands the set of `literalizer` exceptions wrapped into clean `Error:` CLI messages (not tracebacks), especially for `--mode call` failures like parameter-count mismatches and languages/tools that don’t support call rendering, and adds/updates tests and help-text regressions to cover these behaviors (including the `--pre-indent-level` + `--variable-name` indentation fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c6f8623f6ccc80588c186779d31c996bb9c39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->