### PR TITLE
chore: define uv version once in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
@@ -79,7 +81,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck
@@ -87,7 +89,7 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt
@@ -95,7 +97,7 @@ repos:
         entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: mypy
@@ -105,7 +107,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: check-manifest
         name: check-manifest
@@ -113,7 +115,7 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright
         name: pyright
@@ -122,14 +124,14 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: deptry
         name: deptry
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-check-fix
@@ -137,7 +139,7 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -145,7 +147,7 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -154,7 +156,7 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ty
@@ -164,7 +166,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly
         name: pyrefly
@@ -173,14 +175,14 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: zizmor
@@ -189,7 +191,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: docs
@@ -198,7 +200,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: sphinx-lint
         name: sphinx-lint
@@ -206,7 +208,7 @@ repos:
           --ignore=docs/build
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: uv-lock
@@ -215,5 +217,5 @@ repos:
         language: python
         pass_filenames: false
         files: (^pyproject\.toml$|^uv\.lock$)
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck
@@ -89,7 +90,8 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt
@@ -97,7 +99,8 @@ repos:
         entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: mypy
@@ -107,7 +110,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: check-manifest
         name: check-manifest
@@ -115,7 +119,8 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright
         name: pyright
@@ -124,14 +129,16 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: deptry
         name: deptry
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-check-fix
@@ -139,7 +146,8 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -147,7 +155,8 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -156,7 +165,8 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ty
@@ -166,7 +176,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyrefly
         name: pyrefly
@@ -175,14 +186,16 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: zizmor
@@ -191,7 +204,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: docs
@@ -200,7 +214,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: sphinx-lint
         name: sphinx-lint
@@ -208,7 +223,8 @@ repos:
           --ignore=docs/build
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: uv-lock
@@ -217,5 +233,6 @@ repos:
         language: python
         pass_filenames: false
         files: (^pyproject\.toml$|^uv\.lock$)
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -52,8 +52,9 @@ Options:
   --declaration-style TEXT        Declaration style (language-specific).
                                   Choices: assign, auto, block, colon, const,
                                   declare, def, define, defparameter, dim,
-                                  final, let, let_mut, let_mutable, local, mut,
-                                  my, set, short, static, typed, val, var.
+                                  final, lazy_static, let, let_mut, let_mutable,
+                                  local, mut, my, set, short, static, typed,
+                                  val, var.
   --dict-entry-style TEXT         Dict entry style (language-specific). Choices:
                                   default, rocket, symbol.
   --dict-format TEXT              Dict format (language-specific). Choices:


### PR DESCRIPTION
Matches the pattern from [literalizer](https://github.com/adamtheturtle/literalizer): a YAML anchor `.uv_version` so the uv pin is declared once and referenced as `*uv_version` in each hook's `additional_dependencies`.

`pre-commit validate-config` may warn about an unexpected root key `.uv_version`; that is expected and matches literalizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config/test snapshot-only changes; behavior should be unchanged aside from pre-commit config parsing/validation quirks around the new root key.
> 
> **Overview**
> Refactors `.pre-commit-config.yaml` to define the pinned `uv` version once (`.uv_version: &uv_version uv==0.9.5`) and reference it from every local hook’s `additional_dependencies` via `*uv_version`.
> 
> Updates the CLI help snapshot (`tests/test_literalizer_cli/test_help.txt`) to include the `lazy_static` `--declaration-style` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60062561165efaed08b6747e491d08dc4f109027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->