### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the pinned `uv` version used by pre-commit hooks, with no runtime or application logic changes.
> 
> **Overview**
> Updates `.pre-commit-config.yaml` to bump the shared `.uv_version` anchor from `uv==0.9.5` to `uv==0.11.7`, affecting the version of `uv` installed for local pre-commit hooks via `additional_dependencies`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f7cbca0ee39ca47d95b1828d652048b8e9b14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->