### PR TITLE
Bump literalizer to 2026.5.13.1 and adopt upstream changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,47 @@ Changelog
 Next
 ----
 
+2026.05.13
+----------
+
+- Bump ``literalizer`` to 2026.5.13.1.  The new release re-exposes the
+  ``supports_*`` class attributes for ``empty_dict_key``, ``call_style``,
+  and the five ``default_*_type`` options, restoring a type-safe probe
+  for runtime-dispatched constructor kwargs (cf. upstream issue
+  #2147).
+- Replace ``--line-ending`` with ``--statement-terminator-style``.  The
+  upstream ``LineEndings`` enum was removed; ``StatementTerminatorStyles``
+  (``semicolon``, ``none``) is its successor.
+- Add ``--call-style`` for picking between per-language call shapes
+  (e.g. ``curried`` for Haskell / OCaml / F# / SML / Elm, ``named`` for
+  Visual Basic).
+- Add ``--numeric-style`` for languages that support multiple numeric
+  rendering styles (e.g. ``overloaded`` vs. ``explicit``).
+- Add ``--language-version`` for selecting the target language version
+  (each language exposes a ``VersionFormats`` enum).
+- Add ``--module-name`` for languages whose ``--wrap-in-file`` form
+  introduces a named scope (C, C++, D, Erlang, Fortran, F#, Java,
+  Objective-C, Occam, SystemVerilog).  Previously a ``module_name``
+  argument to ``literalize`` itself, now a per-language constructor
+  argument.
+- Add ``--ref-key`` for picking a marker key other than ``$ref`` for
+  variable-reference mappings in the input data.
+- Surface the new typed ``literalizer`` exceptions as clean CLI errors
+  rather than tracebacks: ``UnsupportedCallShapeError``,
+  ``VariableNameNotSupportedError``,
+  ``WrapInFileWithoutVariableNotSupportedError``,
+  ``WrapCombinedInFileNotSupportedError``,
+  ``DottedCallTargetNotSupportedError``,
+  ``DottedCallStubNotSupportedError``,
+  ``FreeFunctionCallNotSupportedError``,
+  ``CallArgNotSupportedError``,
+  ``HeterogeneousScalarCollectionError``,
+  ``UnrepresentableSpecialFloatError``.
+- ``--variable-type-hints auto`` is now ``--variable-type-hints never``
+  (upstream rename), with a new ``safe`` option that annotates only
+  when the language's own inference would widen the variable to a
+  permissive type (e.g. ``unknown[]`` for an empty TypeScript array).
+
 2026.04.30
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.4.29",
+    "literalizer==2026.5.13.1",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -63,8 +63,11 @@ _OPTION_TO_ENUM: dict[str, Callable[[LanguageCls], type[enum.Enum]]] = {
     "string_format": lambda cls: cls.StringFormats,
     "trailing_comma": lambda cls: cls.TrailingCommas,
     "empty_dict_key": lambda cls: cls.EmptyDictKey,
-    "line_ending": lambda cls: cls.LineEndings,
+    "statement_terminator_style": lambda cls: cls.StatementTerminatorStyles,
     "heterogeneous_strategy": lambda cls: cls.HeterogeneousStrategies,
+    "call_style": lambda cls: cls.CallStyles,
+    "numeric_style": lambda cls: cls.NumericStyles,
+    "language_version": lambda cls: cls.VersionFormats,
 }
 
 
@@ -77,10 +80,45 @@ def _get_enum_for_option(
     return _OPTION_TO_ENUM[option_name](lang_cls)
 
 
+# Constructor options that only some languages accept.  For each, a
+# getter reads the ``supports_*`` flag that ``literalizer`` exposes on
+# :class:`LanguageCls`.  Options not in this map are accepted by every
+# language and need no support probe.
+_OPTION_SUPPORT_FLAG: dict[str, Callable[[LanguageCls], bool]] = {
+    "module_name": lambda cls: cls.supports_module_name,
+    "empty_dict_key": lambda cls: cls.supports_empty_dict_key,
+    "call_style": lambda cls: cls.supports_call_style,
+    "default_dict_key_type": (lambda cls: cls.supports_default_dict_key_type),
+    "default_dict_value_type": (
+        lambda cls: cls.supports_default_dict_value_type
+    ),
+    "default_sequence_element_type": (
+        lambda cls: cls.supports_default_sequence_element_type
+    ),
+    "default_set_element_type": (
+        lambda cls: cls.supports_default_set_element_type
+    ),
+    "default_ordered_map_value_type": (
+        lambda cls: cls.supports_default_ordered_map_value_type
+    ),
+}
+
+
+def _language_accepts_param(*, lang_cls: LanguageCls, name: str) -> bool:
+    """Return whether the language's constructor accepts ``name``."""
+    getter = _OPTION_SUPPORT_FLAG.get(name)
+    return getter is None or getter(lang_cls)
+
+
 def _all_choices_for_option(option_name: str) -> list[str]:
     """Collect all valid enum member names for an option."""
     members: set[str] = set()
     for lang_cls in ALL_LANGUAGES:
+        if not _language_accepts_param(
+            lang_cls=lang_cls,
+            name=option_name,
+        ):
+            continue
         enum_cls = _get_enum_for_option(
             lang_cls=lang_cls,
             option_name=option_name,
@@ -165,13 +203,25 @@ _EMPTY_DICT_KEY_HELP = _choices_help(
     label="Empty dict key handling",
     option_name="empty_dict_key",
 )
-_LINE_ENDING_HELP = _choices_help(
-    label="Line ending style",
-    option_name="line_ending",
+_STATEMENT_TERMINATOR_STYLE_HELP = _choices_help(
+    label="Statement terminator style",
+    option_name="statement_terminator_style",
 )
 _HETEROGENEOUS_STRATEGY_HELP = _choices_help(
     label="Heterogeneous-collection strategy",
     option_name="heterogeneous_strategy",
+)
+_CALL_STYLE_HELP = _choices_help(
+    label="Call style",
+    option_name="call_style",
+)
+_NUMERIC_STYLE_HELP = _choices_help(
+    label="Numeric style",
+    option_name="numeric_style",
+)
+_LANGUAGE_VERSION_HELP = _choices_help(
+    label="Target language version",
+    option_name="language_version",
 )
 
 
@@ -221,25 +271,17 @@ def _resolve_modifiers(
 
 
 # Language options that take a free-form string rather than an enum.
-# Maps CLI option name to a getter for the ``supports_*`` flag.
-_STRING_OPTIONS: dict[
-    str,
-    Callable[[LanguageCls], bool],
-] = {
-    "default_dict_key_type": (lambda cls: cls.supports_default_dict_key_type),
-    "default_dict_value_type": (
-        lambda cls: cls.supports_default_dict_value_type
-    ),
-    "default_sequence_element_type": (
-        lambda cls: cls.supports_default_sequence_element_type
-    ),
-    "default_set_element_type": (
-        lambda cls: cls.supports_default_set_element_type
-    ),
-    "default_ordered_map_value_type": (
-        lambda cls: cls.supports_default_ordered_map_value_type
-    ),
-}
+# Each is supported only by languages whose constructor accepts it.
+_STRING_OPTIONS: frozenset[str] = frozenset(
+    {
+        "default_dict_key_type",
+        "default_dict_value_type",
+        "default_sequence_element_type",
+        "default_set_element_type",
+        "default_ordered_map_value_type",
+        "module_name",
+    },
+)
 
 
 def _resolve_language_option(
@@ -273,6 +315,7 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.TOMLParseError,
     literalizer.exceptions.InvalidDictKeyError,
     literalizer.exceptions.HeterogeneousCollectionError,
+    literalizer.exceptions.HeterogeneousScalarCollectionError,
     literalizer.exceptions.NullInCollectionError,
     literalizer.exceptions.PerElementNotListError,
     literalizer.exceptions.ParameterCountMismatchError,
@@ -280,7 +323,16 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.CallsNotSupportedByToolError,
     literalizer.exceptions.IncompatibleFormatsError,
     literalizer.exceptions.UnrepresentableIntegerError,
+    literalizer.exceptions.UnrepresentableSpecialFloatError,
     literalizer.exceptions.UnsupportedIdentifierCaseError,
+    literalizer.exceptions.UnsupportedCallShapeError,
+    literalizer.exceptions.VariableNameNotSupportedError,
+    literalizer.exceptions.WrapInFileWithoutVariableNotSupportedError,
+    literalizer.exceptions.WrapCombinedInFileNotSupportedError,
+    literalizer.exceptions.DottedCallTargetNotSupportedError,
+    literalizer.exceptions.DottedCallStubNotSupportedError,
+    literalizer.exceptions.FreeFunctionCallNotSupportedError,
+    literalizer.exceptions.CallArgNotSupportedError,
 )
 
 
@@ -294,6 +346,7 @@ def literalize_input(
     variable_form: VariableForm | None,
     wrap_in_file: bool,
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> LiteralizeResult:
     """Literalize input and surface literalizer errors as CLI errors."""
     try:
@@ -306,6 +359,7 @@ def literalize_input(
             variable_form=variable_form,
             wrap_in_file=wrap_in_file,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
@@ -321,6 +375,7 @@ def literalize_call_input(
     per_element: bool,
     wrap_in_file: bool,
     ref_case: IdentifierCase | None,
+    ref_key: str,
 ) -> LiteralizeResult:
     """Literalize input as function calls, surfacing errors as CLI errors."""
     try:
@@ -333,6 +388,7 @@ def literalize_call_input(
             per_element=per_element,
             wrap_in_file=wrap_in_file,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
@@ -477,14 +533,38 @@ def literalize_call_input(
     help=_EMPTY_DICT_KEY_HELP,
 )
 @click.option(
-    "--line-ending",
+    "--statement-terminator-style",
     default=None,
-    help=_LINE_ENDING_HELP,
+    help=_STATEMENT_TERMINATOR_STYLE_HELP,
 )
 @click.option(
     "--heterogeneous-strategy",
     default=None,
     help=_HETEROGENEOUS_STRATEGY_HELP,
+)
+@click.option(
+    "--call-style",
+    default=None,
+    help=_CALL_STYLE_HELP,
+)
+@click.option(
+    "--numeric-style",
+    default=None,
+    help=_NUMERIC_STYLE_HELP,
+)
+@click.option(
+    "--language-version",
+    default=None,
+    help=_LANGUAGE_VERSION_HELP,
+)
+@click.option(
+    "--module-name",
+    default=None,
+    help=(
+        "Module/namespace name for languages whose wrap-in-file form"
+        " introduces a named scope (e.g. C, C++, D, Erlang, Fortran, F#,"
+        " Java, Objective-C, Occam, SystemVerilog)."
+    ),
 )
 @click.option(
     "--default-dict-key-type",
@@ -559,6 +639,16 @@ def literalize_call_input(
         "as nested dicts."
     ),
 )
+@click.option(
+    "--ref-key",
+    default="$ref",
+    show_default=True,
+    help=(
+        "Marker key used to identify variable-reference mappings in the "
+        "input data. A single-key dict whose key equals --ref-key and whose "
+        "value is a string is treated as a ref marker."
+    ),
+)
 def main(
     *,
     language: str,
@@ -587,8 +677,12 @@ def main(
     string_format: str | None,
     trailing_comma: str | None,
     empty_dict_key: str | None,
-    line_ending: str | None,
+    statement_terminator_style: str | None,
     heterogeneous_strategy: str | None,
+    call_style: str | None,
+    numeric_style: str | None,
+    language_version: str | None,
+    module_name: str | None,
     default_dict_key_type: str | None,
     default_dict_value_type: str | None,
     default_sequence_element_type: str | None,
@@ -600,6 +694,7 @@ def main(
     call_params: str | None,
     per_element: bool,
     ref_case: str | None,
+    ref_key: str,
 ) -> None:
     """Convert data structures to native language literal syntax."""
     input_string = sys.stdin.read()
@@ -624,11 +719,25 @@ def main(
         "string_format": string_format,
         "trailing_comma": trailing_comma,
         "empty_dict_key": empty_dict_key,
-        "line_ending": line_ending,
+        "statement_terminator_style": statement_terminator_style,
         "heterogeneous_strategy": heterogeneous_strategy,
+        "call_style": call_style,
+        "numeric_style": numeric_style,
+        "language_version": language_version,
     }
     for option_name, value in cli_language_options.items():
         if value is not None:
+            if not _language_accepts_param(
+                lang_cls=lang_cls,
+                name=option_name,
+            ):
+                lang_name = lang_cls.__name__.lower()
+                raise click.UsageError(
+                    message=(
+                        f"--{option_name.replace('_', '-')} is not "
+                        f"supported for language '{lang_name}'."
+                    ),
+                )
             lang_kwargs[option_name] = _resolve_language_option(
                 lang_cls=lang_cls,
                 option_name=option_name,
@@ -641,10 +750,13 @@ def main(
         "default_sequence_element_type": default_sequence_element_type,
         "default_set_element_type": default_set_element_type,
         "default_ordered_map_value_type": default_ordered_map_value_type,
+        "module_name": module_name,
     }
     for option_name, value in cli_string_options.items():
         if value is not None:
-            if not _STRING_OPTIONS[option_name](lang_cls):
+            if option_name not in _STRING_OPTIONS or not (
+                _language_accepts_param(lang_cls=lang_cls, name=option_name)
+            ):
                 lang_name = lang_cls.__name__.lower()
                 raise click.UsageError(
                     message=(
@@ -706,6 +818,7 @@ def main(
             per_element=per_element,
             wrap_in_file=wrap_in_file,
             ref_case=resolved_ref_case,
+            ref_key=ref_key,
         )
     else:
         result = literalize_input(
@@ -717,6 +830,7 @@ def main(
             variable_form=variable_form,
             wrap_in_file=wrap_in_file,
             ref_case=resolved_ref_case,
+            ref_key=ref_key,
         )
     if include_preamble:
         for preamble_line in result.preamble:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -121,11 +121,11 @@ def test_ref_case_unsupported_for_language() -> None:
         cli=main,
         args=[
             "--language",
-            "python",
+            "bash",
             "--input-format",
             "json",
             "--ref-case",
-            "camel",
+            "kebab",
         ],
         input='{"a": {"$ref": "userId"}}\n',
         catch_exceptions=False,
@@ -134,7 +134,7 @@ def test_ref_case_unsupported_for_language() -> None:
     assert result.exit_code == 1
     assert (
         result.output
-        == "Error: Python does not support identifier case 'CAMEL'\n"
+        == "Error: Bash does not support identifier case 'KEBAB'\n"
     )
 
 
@@ -319,6 +319,78 @@ def test_heterogeneous_collection_error() -> None:
     assert result.output == expected
 
 
+def test_wrap_in_file_without_variable_unsupported() -> None:
+    """Strict-typed langs reject ``--wrap-in-file`` without a variable."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "rust",
+            "-f",
+            "json",
+            "--wrap-in-file",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = (
+        "Error: Rust cannot wrap a bare value"
+        " (without a variable_form) at file scope\n"
+    )
+    assert result.output == expected
+
+
+def test_variable_name_unsupported_for_language() -> None:
+    """Data-format languages reject ``--variable-name``."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "yaml",
+            "-f",
+            "json",
+            "--variable-name",
+            "data",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = "Error: Yaml does not support variable names: 'data'\n"
+    assert result.output == expected
+
+
+def test_dotted_call_target_unsupported_for_language() -> None:
+    """HCL rejects dotted ``--call-function`` targets."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "hcl",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "a.b",
+            "--call-params",
+            "x",
+        ],
+        input="[[1]]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = "Error: Hcl does not support dotted call targets: 'a.b'\n"
+    assert result.output == expected
+
+
 def test_invalid_json_is_shown_cleanly() -> None:
     """JSON parse failures are shown as CLI errors."""
     runner = CliRunner()
@@ -427,6 +499,7 @@ def test_literalizer_exceptions_are_wrapped_as_click_exceptions(
             variable_form=case.variable_form,
             wrap_in_file=False,
             ref_case=None,
+            ref_key="$ref",
         )
 
     assert exc_info.value.message == case.expected
@@ -626,8 +699,8 @@ def test_sequence_format_case_insensitive() -> None:
     assert result.output == expected
 
 
-def test_line_ending() -> None:
-    """--line-ending changes the line ending style."""
+def test_statement_terminator_style() -> None:
+    """--statement-terminator-style controls trailing terminator emission."""
     runner = CliRunner()
     result = runner.invoke(
         cli=main,
@@ -638,7 +711,7 @@ def test_line_ending() -> None:
             "json",
             "--variable-name",
             "data",
-            "--line-ending",
+            "--statement-terminator-style",
             "none",
         ],
         input='{"a": 1}\n',
@@ -646,8 +719,142 @@ def test_line_ending() -> None:
         color=True,
     )
     assert result.exit_code == 0
-    # With line_ending=none, JavaScript should omit the trailing semicolon.
+    # With statement_terminator_style=none, JavaScript omits the
+    # trailing semicolon.
     assert ";" not in result.output
+
+
+def test_call_style_curried_haskell() -> None:
+    """--call-style curried emits curried Haskell applications."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "haskell",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "process",
+            "--call-params",
+            "x,y",
+            "--call-style",
+            "curried",
+        ],
+        input="[[1, 2]]\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert result.output.rstrip().endswith("process (1) (2)")
+
+
+def test_module_name() -> None:
+    """--module-name controls the wrap-in-file scope name."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "java",
+            "-f",
+            "json",
+            "--wrap-in-file",
+            "--module-name",
+            "MyMod",
+            "--variable-name",
+            "data",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert "class MyMod {" in result.output
+
+
+def test_module_name_unsupported_for_language() -> None:
+    """--module-name rejects languages whose wrapper has no named scope."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--module-name",
+            "MyMod",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    expected_usage_error_exit_code = 2
+    assert result.exit_code == expected_usage_error_exit_code
+    assert (
+        "--module-name is not supported for language 'python'" in result.output
+    )
+
+
+def test_language_version() -> None:
+    """--language-version selects a target version for the language."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--language-version",
+            "py_3_12",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "a": 1,
+        }
+    """
+    )
+    assert result.output == expected
+
+
+def test_ref_key() -> None:
+    """--ref-key selects a different marker key for $ref-style entries."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--ref-key",
+            "_ref",
+            "--ref-case",
+            "snake",
+        ],
+        input='{"a": {"_ref": "user_id"}}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    expected = textwrap.dedent(
+        text="""\
+        {
+            "a": user_id,
+        }
+    """
+    )
+    assert result.output == expected
 
 
 def test_default_dict_key_type() -> None:
@@ -1332,7 +1539,7 @@ def test_call_mode_not_implemented_for_language() -> None:
         cli=main,
         args=[
             "-l",
-            "cobol",
+            "nix",
             "-f",
             "json",
             "--mode",
@@ -1348,8 +1555,7 @@ def test_call_mode_not_implemented_for_language() -> None:
     )
     assert result.exit_code == 1
     expected = (
-        "Error: literalizer does not support "
-        "function call rendering for Cobol\n"
+        "Error: literalizer does not support function call rendering for Nix\n"
     )
     assert result.output == expected
 

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -751,6 +751,28 @@ def test_call_style_curried_haskell() -> None:
     assert result.output.rstrip().endswith("process (1) (2)")
 
 
+def test_call_style_unsupported_for_language() -> None:
+    """--call-style rejects languages whose constructor lacks the option."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "yaml",
+            "-f",
+            "json",
+            "--call-style",
+            "positional",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    expected_usage_error_exit_code = 2
+    assert result.exit_code == expected_usage_error_exit_code
+    assert "--call-style is not supported for language 'yaml'" in result.output
+
+
 def test_module_name() -> None:
     """--module-name controls the wrap-in-file scope name."""
     runner = CliRunner()

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -48,7 +48,7 @@ Options:
                                   paren_star, percent, semicolon, slash,
                                   star_angle.
   --variable-type-hints TEXT      Variable type hints (language-specific).
-                                  Choices: always, auto.
+                                  Choices: always, never, safe.
   --declaration-style TEXT        Declaration style (language-specific).
                                   Choices: assign, auto, block, colon, const,
                                   declare, def, define, defparameter, dim,
@@ -76,13 +76,32 @@ Options:
   --trailing-comma TEXT           Trailing comma (language-specific). Choices:
                                   no, yes.
   --empty-dict-key TEXT           Empty dict key handling (language-specific).
-                                  Choices: allow, error, positional.
-  --line-ending TEXT              Line ending style (language-specific).
-                                  Choices: newline, none, semicolon.
+                                  Choices: error, positional.
+  --statement-terminator-style TEXT
+                                  Statement terminator style (language-
+                                  specific). Choices: newline, none, semicolon.
   --heterogeneous-strategy TEXT   Heterogeneous-collection strategy (language-
                                   specific). Choices: error, interface,
                                   object_variant, tagged_enum, union_type,
                                   variant.
+  --call-style TEXT               Call style (language-specific). Choices:
+                                  command, curried, keyword, named, object,
+                                  positional, prefix, prefix_keyword.
+  --numeric-style TEXT            Numeric style (language-specific). Choices:
+                                  explicit, overloaded.
+  --language-version TEXT         Target language version (language-specific).
+                                  Choices: ada_2022, ans, ansi, c99, cpp20,
+                                  dev_2024, dotnet_6, edition_2021, es2015,
+                                  haskell_2010, ieee_1800_2017, jdk_11, otp_25,
+                                  py_3_12, r2022a, r7rs, sml_97, v0, v0_12,
+                                  v0_14, v0_15, v0_19, v0_20, v0_4, v1, v10,
+                                  v17, v1_11, v1_14, v1_18, v1_2, v1_9, v2,
+                                  v2002, v2003, v24_5, v3, v4, v5, v5_1, v5_36,
+                                  v5_4, v5_9, v6, v6d, v7, v8, v8_1, v8_6.
+  --module-name TEXT              Module/namespace name for languages whose
+                                  wrap-in-file form introduces a named scope
+                                  (e.g. C, C++, D, Erlang, Fortran, F#, Java,
+                                  Objective-C, Occam, SystemVerilog).
   --default-dict-key-type TEXT    Default type for dict keys (language-specific,
                                   free-form string).
   --default-dict-value-type TEXT  Default type for dict values (language-
@@ -113,4 +132,9 @@ Options:
                                   "name"}`` are emitted as bare identifiers re-
                                   cased to the chosen convention instead of as
                                   nested dicts.
+  --ref-key TEXT                  Marker key used to identify variable-reference
+                                  mappings in the input data. A single-key dict
+                                  whose key equals --ref-key and whose value is
+                                  a string is treated as a ref marker.
+                                  [default: $ref]
   --help                          Show this message and exit.

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.29"
+version = "2026.5.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -565,9 +565,9 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/3f/dc3db7939c6f7023b191247e31ef13ebaf38986c074f057c36b3a5c0bbf9/literalizer-2026.4.29.tar.gz", hash = "sha256:95d1323be12e5d63022a41cea249ffb379ed8943d0bfc5a6f88e23de5f4e144e", size = 1551951, upload-time = "2026-04-29T21:38:23.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/cf/c7eb11e5ea724361cfa0d0e91e33b7975309f78827dca5d27219a6ce239c/literalizer-2026.5.13.1.tar.gz", hash = "sha256:2ee8d970e88b991b75bd769374ecbbd2771b5b8ddd32674f2ff8ee2736ff9db4", size = 2057844, upload-time = "2026-05-13T11:29:58.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ab/78f9eeed4a2ce8c3204745586a29541a60f5191670928ac132ca2978dd9c/literalizer-2026.4.29-py3-none-any.whl", hash = "sha256:6184223adbac3484ff846c05b380e907f492bd598917e3627b8f0e0730082323", size = 468881, upload-time = "2026-04-29T21:38:21.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/67/4211c4292d49525b313ceece2f35f8200419980f191d36dffb7d5c139aee/literalizer-2026.5.13.1-py3-none-any.whl", hash = "sha256:b3d05fba6fb2f3460a135e7cf0487adf95f3a0e96e4842a7fc4d46d3e33aa853", size = 544758, upload-time = "2026-05-13T11:29:56.771Z" },
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.4.29" },
+    { name = "literalizer", specifier = "==2026.5.13.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.13" },


### PR DESCRIPTION
## Summary

- Bumps ``literalizer`` from 2026.4.29 to 2026.5.13.1.
- Replaces removed ``--line-ending`` with ``--statement-terminator-style`` and adds ``--call-style``, ``--numeric-style``, ``--language-version``, ``--module-name``, and ``--ref-key``.
- Uses the upstream ``supports_*`` class attributes (re-exposed in 2026.5.13.1) to probe per-language constructor kwarg support without dataclass introspection or ``cast``/``type: ignore``.
- Surfaces the new typed ``literalizer`` exceptions (``WrapInFileWithoutVariableNotSupportedError``, ``VariableNameNotSupportedError``, ``DottedCallTargetNotSupportedError``, ``HeterogeneousScalarCollectionError``, and others) as clean CLI errors, with end-to-end tests for the CLI-reachable ones.

## Test plan

- [x] ``uv run pytest`` — 66 passed
- [x] ``uv run mypy src/ tests/`` — clean
- [x] ``uv run ty check src/`` — clean
- [x] ``uv run pyright src/`` — clean
- [x] ``uv run ruff check src/ tests/`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the core `literalizer` dependency and reworks several CLI options/kwargs, which can change output formatting and error behavior across languages. Risk is moderated by expanded CLI coverage tests but could still introduce compatibility regressions for existing scripts.
> 
> **Overview**
> Bumps `literalizer` to `2026.5.13.1` and updates docs/lockfiles accordingly.
> 
> Adopts upstream CLI/API changes: replaces `--line-ending` with `--statement-terminator-style`, adds new language configuration flags (`--call-style`, `--numeric-style`, `--language-version`, `--module-name`) and a customizable ref marker via `--ref-key` (passed through to both `literalize` and `literalize_call`).
> 
> Refactors per-language option handling to use upstream `supports_*` probes for constructor kwarg support, emitting `UsageError` when an option isn’t supported, and expands wrapped exception handling so new typed `literalizer` errors surface as clean CLI messages with new end-to-end tests and updated `--help` expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f05d986536ee83104c68e5d0788c22c001d7c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->