### PR TITLE
Bump literalizer to 2026.5.14 and adopt upstream changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ Changelog
 Next
 ----
 
+2026.05.14
+----------
+
+- Bump ``literalizer`` to 2026.5.14.
+- ``--variable-name`` (with ``--new-variable`` / ``--no-new-variable``
+  and ``--modifier``) now applies in ``--mode call`` as well, wrapping
+  the rendered call in the language's idiomatic per-language variable
+  binding (e.g. ``let user = createUser(...)``,
+  ``const user = createUser(...)``,
+  ``user = create_user(...)``).  Mutability and inference are picked
+  up from ``--declaration-style`` and ``--modifier`` exactly as in
+  literal mode.  Languages whose declaration template wraps or
+  transforms the right-hand side in a way only valid for literal
+  values (e.g. Bash command substitution, Objective-C boxing,
+  tagged-enum heterogeneous-strategy languages) surface the upstream
+  ``UnsupportedCallShapeError`` as a clean CLI error, as does the
+  combination with ``--per-element`` (which has no per-element name
+  vector).
+
 2026.05.13
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.5.13.1",
+    "literalizer==2026.5.14",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -376,6 +376,7 @@ def literalize_call_input(
     wrap_in_file: bool,
     ref_case: IdentifierCase | None,
     ref_key: str,
+    variable_form: VariableForm | None,
 ) -> LiteralizeResult:
     """Literalize input as function calls, surfacing errors as CLI errors."""
     try:
@@ -389,6 +390,7 @@ def literalize_call_input(
             wrap_in_file=wrap_in_file,
             ref_case=ref_case,
             ref_key=ref_key,
+            variable_form=variable_form,
         )
     except _LITERALIZER_EXCEPTIONS as exc:
         raise click.ClickException(message=str(object=exc)) from None
@@ -819,6 +821,7 @@ def main(
             wrap_in_file=wrap_in_file,
             ref_case=resolved_ref_case,
             ref_key=ref_key,
+            variable_form=variable_form,
         )
     else:
         result = literalize_input(

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -1418,6 +1418,97 @@ def test_call_mode_javascript() -> None:
     assert "createUser(" in result.output
 
 
+def test_call_mode_variable_name_new_variable() -> None:
+    """``--variable-name`` in call mode wraps the call in a declaration."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "javascript",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "createUser",
+            "--call-params",
+            "name",
+            "--no-per-element",
+            "--variable-name",
+            "user",
+        ],
+        input='{"name": "alice"}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    expected = 'const user = createUser({ name: {"name": "alice"} });\n'
+    assert result.output == expected
+
+
+def test_call_mode_variable_name_existing_variable() -> None:
+    """``--no-new-variable`` in call mode emits a bare assignment."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "create_user",
+            "--call-params",
+            "name",
+            "--no-per-element",
+            "--variable-name",
+            "user",
+            "--no-new-variable",
+        ],
+        input='{"name": "alice"}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == 'user = create_user(name={"name": "alice"})\n'
+
+
+def test_call_mode_variable_name_unsupported_shape() -> None:
+    """Languages that cannot wrap a call in a binding raise a clean error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "bash",
+            "-f",
+            "json",
+            "--mode",
+            "call",
+            "--call-function",
+            "create_user",
+            "--call-params",
+            "name",
+            "--no-per-element",
+            "--variable-name",
+            "user",
+        ],
+        input='{"name": "alice"}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert result.output == (
+        "Error: Bash cannot represent this call shape: this language's "
+        "variable-declaration template wraps or transforms the right-hand "
+        "side in a way that is only valid for literal values, not call "
+        "expressions\n"
+    )
+
+
 def test_call_mode_invalid_json() -> None:
     """Call mode surfaces JSON parse errors as CLI errors."""
     runner = CliRunner()

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.13.1"
+version = "2026.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -564,10 +564,11 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/cf/c7eb11e5ea724361cfa0d0e91e33b7975309f78827dca5d27219a6ce239c/literalizer-2026.5.13.1.tar.gz", hash = "sha256:2ee8d970e88b991b75bd769374ecbbd2771b5b8ddd32674f2ff8ee2736ff9db4", size = 2057844, upload-time = "2026-05-13T11:29:58.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/37/1212e92f23bcc744a1e826e1f4b848195b4c673f414a94caf9ac6a55dc91/literalizer-2026.5.14.tar.gz", hash = "sha256:23ab68bc619677803e0df0b0c887b648fb348adfedb4f8e6da96dcee7bff8cfe", size = 2105743, upload-time = "2026-05-14T07:50:01.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/67/4211c4292d49525b313ceece2f35f8200419980f191d36dffb7d5c139aee/literalizer-2026.5.13.1-py3-none-any.whl", hash = "sha256:b3d05fba6fb2f3460a135e7cf0487adf95f3a0e96e4842a7fc4d46d3e33aa853", size = 544758, upload-time = "2026-05-13T11:29:56.771Z" },
+    { url = "https://files.pythonhosted.org/packages/79/1e/2e4f6a821961f4106d93430e47621b45fabf0c358e9eadb868c9dda13c85/literalizer-2026.5.14-py3-none-any.whl", hash = "sha256:24d8b5abc13a84b11af1c0b8c12d37dde7018fdf423627f9cc378f89078e7828", size = 558059, upload-time = "2026-05-14T07:49:59.157Z" },
 ]
 
 [[package]]
@@ -624,7 +625,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.5.13.1" },
+    { name = "literalizer", specifier = "==2026.5.14" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.13" },
@@ -638,7 +639,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "setuptools", marker = "extra == 'release'", specifier = ">=70,<83" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
-    { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==3.12.0.2" },
+    { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=8.1.3" },
     { name = "sphinx-click", marker = "extra == 'dev'", specifier = "==6.2.0" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'", specifier = "==0.5.2" },
@@ -1638,9 +1639,16 @@ wheels = [
 
 [[package]]
 name = "shfmt-py"
-version = "3.12.0.2"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d5/c2ad5c6593a34da7344cf39bde65763e8cda752589074ba1619e55b317ad/shfmt_py-4.0.0.tar.gz", hash = "sha256:1e5fdacf40aabaa77a97639d52a6220df0893b46658d82b7f136f4e66e2b2fb0", size = 11947, upload-time = "2026-05-13T09:25:50.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/1d/8f72824e2a0e06dc0bc2687baacaba0573be7d2e93c01d1e895fddd8c13e/shfmt_py-4.0.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75a4919a03fb3bcff9795e3cc7b971e37e74905654d2f11605001cab42e5f92f", size = 1343695, upload-time = "2026-05-13T09:25:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/82/9564a2c2a76fbec94db1b3a3c37a9a1d00e7eafca2cdd2e0d19082618d7e/shfmt_py-4.0.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb3d236163ff39c7790953e069938caf247e7646399f7a059f00f65d4e6916d6", size = 1237947, upload-time = "2026-05-13T09:25:44.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/6fce944efa530db941edd11388d70dc7384aaf12169a3b0847b6a6c987b0/shfmt_py-4.0.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4701336c3cb5f3959a5e85481b14f02054ea094b3c666f3d04649bbe10de3c25", size = 1218771, upload-time = "2026-05-13T09:25:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/64/43/e3965a25bb39555f2791c6860214f62b6f976f9ac7e9786073364bcdd9a6/shfmt_py-4.0.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:e57877abe0177a9da7bbb5390fe7e96aa19b00958189a025634039aef8834d44", size = 1350939, upload-time = "2026-05-13T09:25:47.584Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/db2430d9262d2cffadcad2b330441e13031f1ab849ec069659edb7f23257/shfmt_py-4.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:bd4f3d36264d4ba8b014ff73e5e702aaa2345845c021f563480128de3705135b", size = 1427721, upload-time = "2026-05-13T09:25:48.865Z" },
+]
 
 [[package]]
 name = "snowballstemmer"


### PR DESCRIPTION
## Summary
- Bump ``literalizer`` to 2026.5.14.
- ``--variable-name`` (with ``--new-variable`` / ``--no-new-variable`` and ``--modifier``) now applies in ``--mode call`` as well, wrapping the rendered call in the language's idiomatic binding (e.g. ``let user = createUser(...)``, ``const user = createUser(...)``, ``user = create_user(...)``). Languages whose declaration template can't host a call expression (Bash, Objective-C, tagged-enum strategies, ...) surface the upstream ``UnsupportedCallShapeError`` as a clean CLI error.

## Test plan
- [x] ``uv run pytest`` (70 passed)
- [x] ``uv run mypy src/ tests/``
- [x] ``uv run ruff check src/ tests/``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior of `--mode call` output changes when `--variable-name` is provided, and the `literalizer` dependency bump may affect rendering/error behavior across languages.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.5.14` (and updates lockfiles), pulling in upstream behavior changes.
> 
> Extends `--variable-name` (plus `--new-variable`/`--no-new-variable` and `--modifier`) to apply in `--mode call`, wrapping rendered calls in the target language’s declaration/assignment form, and surfaces `UnsupportedCallShapeError` (and the incompatible `--per-element` combination) as clean CLI errors. Adds tests covering new-variable declarations, existing-variable assignments, and unsupported call-shape errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a216d515e578db6469428860bccd78da04eb88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->