### PR TITLE
Bump literalizer to 2026.5.14.1 and adopt upstream changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 Next
 ----
 
+2026.05.14.1
+------------
+
+- Bump ``literalizer`` to 2026.5.14.1.
+- YAML inputs with non-string dict keys (integers, dates, booleans)
+  now flow through to the target language's value-formatting path
+  instead of being silently stringified.  Languages that can represent
+  the key natively (Python, Ruby, Clojure, Lua, Bash, and others)
+  produce the corresponding literal; languages whose dict syntax
+  requires string keys or a homogeneous typed map surface the new
+  upstream ``UnrepresentableInputError`` as a clean CLI error.
+
 2026.05.14
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.5.14",
+    "literalizer==2026.5.14.1",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -322,6 +322,7 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.CallsNotSupportedByLanguageError,
     literalizer.exceptions.CallsNotSupportedByToolError,
     literalizer.exceptions.IncompatibleFormatsError,
+    literalizer.exceptions.UnrepresentableInputError,
     literalizer.exceptions.UnrepresentableIntegerError,
     literalizer.exceptions.UnrepresentableSpecialFloatError,
     literalizer.exceptions.UnsupportedIdentifierCaseError,

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -8,7 +8,7 @@ import pytest
 from click import ClickException
 from click.testing import CliRunner
 from literalizer import ExistingVariable, InputFormat, NewVariable
-from literalizer.languages import Java, Python, R, Rust
+from literalizer.languages import Go, Java, Python, R, Rust
 from pytest_regressions.file_regression import FileRegressionFixture
 
 import literalizer_cli
@@ -59,6 +59,28 @@ def test_literalize_json_to_python() -> None:
         {
             "a": 1,
             "b": (2, 3),
+        }
+    """
+    )
+    assert result.output == expected
+
+
+def test_literalize_yaml_non_string_dict_keys() -> None:
+    """YAML non-string dict keys flow through to the target language."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=["--language", "python", "--input-format", "yaml"],
+        input="1: a\n2: b\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    expected = textwrap.dedent(
+        text="""\
+        {
+            1: "a",
+            2: "b",
         }
     """
     )
@@ -476,6 +498,12 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
                 '  in "<unicode string>", line 2, column 1'
             ),
         ),
+        ExceptionCase(
+            input_format=InputFormat.YAML,
+            input_string="1: a\n2: b\n",
+            language=Go(),
+            expected="Go cannot represent dict key of type int",
+        ),
     ],
     ids=(
         "empty_dict_key",
@@ -483,6 +511,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
         "null_in_collection",
         "json_parse",
         "yaml_parse",
+        "unrepresentable_non_string_dict_key",
     ),
 )
 def test_literalizer_exceptions_are_wrapped_as_click_exceptions(

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.14"
+version = "2026.5.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -566,9 +566,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/37/1212e92f23bcc744a1e826e1f4b848195b4c673f414a94caf9ac6a55dc91/literalizer-2026.5.14.tar.gz", hash = "sha256:23ab68bc619677803e0df0b0c887b648fb348adfedb4f8e6da96dcee7bff8cfe", size = 2105743, upload-time = "2026-05-14T07:50:01.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/a1/fa170c93be94154a1e686a4506f27b265f0738ced3e4ba9df720700310c0/literalizer-2026.5.14.1.tar.gz", hash = "sha256:0eaa0a28c13f50b43a606aba39e24300abffb434a78eb1bfb58803f5bcb0bf58", size = 2119815, upload-time = "2026-05-14T08:34:11.523Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/1e/2e4f6a821961f4106d93430e47621b45fabf0c358e9eadb868c9dda13c85/literalizer-2026.5.14-py3-none-any.whl", hash = "sha256:24d8b5abc13a84b11af1c0b8c12d37dde7018fdf423627f9cc378f89078e7828", size = 558059, upload-time = "2026-05-14T07:49:59.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/51/fc60f6ea5d34039c4469621ca4a49c0b4c5c47a1951dcc3f658cefc90342/literalizer-2026.5.14.1-py3-none-any.whl", hash = "sha256:ab0456b5b19a6d45e75a6c32691c31beb50270c8c5b1c0dd60c2204c07455cda", size = 558379, upload-time = "2026-05-14T08:34:09.923Z" },
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.5.14" },
+    { name = "literalizer", specifier = "==2026.5.14.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.13" },


### PR DESCRIPTION
## Summary

- Bumps ``literalizer`` to 2026.5.14.1 (``pyproject.toml`` and ``uv.lock``).
- Adds the new upstream ``UnrepresentableInputError`` to the CLI's wrapped-exception tuple so YAML non-string dict keys targeting a language with string-only or homogeneous-typed-map dicts surface as a clean Click error instead of an uncaught traceback.
- Languages that can represent non-string dict keys natively (Python, Ruby, Clojure, Lua, Bash, ...) now produce the corresponding literal end-to-end rather than silently stringifying the key.
- Adds a positive test (YAML int keys → Python ``{1: "a", 2: "b"}``) and a wrapped-exception case (Go rejects int keys).

## Test plan

- [x] ``uv run pytest`` (72 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly a dependency patch bump plus extending the existing exception-wrapping list and adding coverage for the new behavior; main impact is changed CLI output/error behavior for YAML maps with non-string keys.
> 
> **Overview**
> Updates the pinned `literalizer` dependency to `2026.5.14.1` (including `uv.lock`) and documents the release in `CHANGELOG.rst`.
> 
> Adopts upstream YAML behavior for non-string dict keys by adding `UnrepresentableInputError` to the CLI’s wrapped exception set, so languages that can’t represent such keys fail with a clean `Error:` message instead of a traceback.
> 
> Adds tests validating that YAML int keys render as native literals for Python, and that Go rejects them with the expected wrapped error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c4e2b9600d08918d43c47d3108731b52d6802e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->