### PR TITLE
Bump literalizer to 2026.5.17 and expose new RECORD/TUPLE features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,34 @@ Changelog
 Next
 ----
 
+- Bump ``literalizer`` to 2026.5.17.
+- Add ``--record-struct-name-prefix`` for naming the structs/records
+  that the ``record`` ``--heterogeneous-strategy`` generates (e.g.
+  ``Widget0``, ``Widget1`` instead of ``Record0``, ``Record1``).  The
+  ``record`` strategy is now available for many more languages in this
+  release (C, C#, C++, Crystal, D, Go, Java, Kotlin, Nim, Odin, Python,
+  Rust, Scala, Swift, V, Zig); the strategy and the new option are
+  surfaced automatically per language exactly like every other
+  language-specific option.
+- ``--heterogeneous-strategy tuple`` is now offered for the languages
+  that gained the upstream ``TUPLE`` strategy (C++, Kotlin, Rust,
+  Scala, TypeScript).  A tuple arity that has no native fixed-size
+  tuple in the target language (e.g. a 4+-element heterogeneous array
+  in Kotlin) now surfaces the new upstream
+  ``TupleArityNotRepresentableError`` as a clean CLI error rather than
+  a traceback.
+- An invalid ``--record-struct-name-prefix`` (not a PascalCase
+  identifier for the target language) now surfaces the upstream
+  ``InvalidRecordNameError`` as a clean CLI error rather than a
+  traceback.
+- ``literalizer`` removed ``DottedCallStubNotSupportedError`` and
+  ``FreeFunctionCallNotSupportedError`` (the context-aware
+  ``call_transform`` made them unreachable); they are no longer
+  referenced.  Languages whose declaration template previously only
+  wrapped literal values (Bash, Objective-C, Tcl, and others) now bind
+  a call result through their idiomatic call-binding form, so
+  ``--variable-name`` in ``--mode call`` works for them too.
+
 2026.05.14.1
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.4.0",
-    "literalizer==2026.5.14.1",
+    "literalizer==2026.5.17",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -101,6 +101,9 @@ _OPTION_SUPPORT_FLAG: dict[str, Callable[[LanguageCls], bool]] = {
     "default_ordered_map_value_type": (
         lambda cls: cls.supports_default_ordered_map_value_type
     ),
+    "record_struct_name_prefix": (
+        lambda cls: cls.supports_record_struct_name_prefix
+    ),
 }
 
 
@@ -280,6 +283,7 @@ _STRING_OPTIONS: frozenset[str] = frozenset(
         "default_set_element_type",
         "default_ordered_map_value_type",
         "module_name",
+        "record_struct_name_prefix",
     },
 )
 
@@ -316,6 +320,7 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.InvalidDictKeyError,
     literalizer.exceptions.HeterogeneousCollectionError,
     literalizer.exceptions.HeterogeneousScalarCollectionError,
+    literalizer.exceptions.TupleArityNotRepresentableError,
     literalizer.exceptions.NullInCollectionError,
     literalizer.exceptions.PerElementNotListError,
     literalizer.exceptions.ParameterCountMismatchError,
@@ -331,8 +336,6 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.WrapInFileWithoutVariableNotSupportedError,
     literalizer.exceptions.WrapCombinedInFileNotSupportedError,
     literalizer.exceptions.DottedCallTargetNotSupportedError,
-    literalizer.exceptions.DottedCallStubNotSupportedError,
-    literalizer.exceptions.FreeFunctionCallNotSupportedError,
     literalizer.exceptions.CallArgNotSupportedError,
 )
 
@@ -605,6 +608,16 @@ def literalize_call_input(
     ),
 )
 @click.option(
+    "--record-struct-name-prefix",
+    default=None,
+    help=(
+        "Name prefix for the structs/records generated under"
+        " --heterogeneous-strategy record (language-specific, free-form"
+        " string). Names must be valid PascalCase identifiers for the"
+        " target language."
+    ),
+)
+@click.option(
     "--include-preamble/--no-include-preamble",
     default=False,
     help="Include language preamble (e.g. package declarations, imports).",
@@ -691,6 +704,7 @@ def main(
     default_sequence_element_type: str | None,
     default_set_element_type: str | None,
     default_ordered_map_value_type: str | None,
+    record_struct_name_prefix: str | None,
     include_preamble: bool,
     mode: str,
     call_function: str | None,
@@ -754,6 +768,7 @@ def main(
         "default_set_element_type": default_set_element_type,
         "default_ordered_map_value_type": default_ordered_map_value_type,
         "module_name": module_name,
+        "record_struct_name_prefix": record_struct_name_prefix,
     }
     for option_name, value in cli_string_options.items():
         if value is not None:
@@ -769,7 +784,10 @@ def main(
                 )
             lang_kwargs[option_name] = value
 
-    lang_instance = lang_cls(indent=indent, **lang_kwargs)
+    try:
+        lang_instance = lang_cls(indent=indent, **lang_kwargs)
+    except literalizer.exceptions.InvalidRecordNameError as exc:
+        raise click.ClickException(message=str(object=exc)) from None
 
     variable_form: VariableForm | None = None
     if variable_name is not None:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -861,7 +861,7 @@ def test_language_version() -> None:
             "-f",
             "json",
             "--language-version",
-            "py_3_12",
+            "py39",
         ],
         input='{"a": 1}\n',
         catch_exceptions=False,
@@ -1506,13 +1506,18 @@ def test_call_mode_variable_name_existing_variable() -> None:
 
 
 def test_call_mode_variable_name_unsupported_shape() -> None:
-    """Languages that cannot wrap a call in a binding raise a clean error."""
+    """An unsupported call/binding shape raises a clean error.
+
+    ``--variable-name`` with per-element calls has no per-element name
+    vector, so ``literalizer`` rejects the combination; the CLI surfaces
+    it as a clean error rather than a traceback.
+    """
     runner = CliRunner()
     result = runner.invoke(
         cli=main,
         args=[
             "-l",
-            "bash",
+            "python",
             "-f",
             "json",
             "--mode",
@@ -1521,20 +1526,19 @@ def test_call_mode_variable_name_unsupported_shape() -> None:
             "create_user",
             "--call-params",
             "name",
-            "--no-per-element",
+            "--per-element",
             "--variable-name",
             "user",
         ],
-        input='{"name": "alice"}\n',
+        input='[{"name": "alice"}, {"name": "bob"}]\n',
         catch_exceptions=False,
         color=True,
     )
     assert result.exit_code == 1
     assert result.output == (
-        "Error: Bash cannot represent this call shape: this language's "
-        "variable-declaration template wraps or transforms the right-hand "
-        "side in a way that is only valid for literal values, not call "
-        "expressions\n"
+        "Error: Python cannot represent this call shape: variable_form is "
+        "incompatible with per_element=True; the API does not provide a "
+        "name per element\n"
     )
 
 
@@ -1644,7 +1648,125 @@ def test_heterogeneous_strategy_invalid_for_language() -> None:
         "Try 'literalize --help' for help.\n"
         "\n"
         "Error: Invalid value 'tagged_enum' for "
-        "--heterogeneous-strategy. Valid choices: error.\n"
+        "--heterogeneous-strategy. Valid choices: error, record.\n"
+    )
+    assert result.output == expected
+
+
+def test_record_struct_name_prefix() -> None:
+    """--record-struct-name-prefix names the generated RECORD structs."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "rust",
+            "-f",
+            "json",
+            "--heterogeneous-strategy",
+            "record",
+            "--record-struct-name-prefix",
+            "Widget",
+            "--variable-name",
+            "data",
+            "--include-preamble",
+        ],
+        input='{"id": 1, "label": "x"}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    expected = (
+        "use std::collections::HashMap;\n"
+        "struct Widget0 {\n"
+        "    id: i32,\n"
+        "    label: &'static str,\n"
+        "}\n"
+        "let data = Widget0 {\n"
+        "    id: 1,\n"
+        '    label: "x",\n'
+        "};\n"
+    )
+    assert result.output == expected
+
+
+def test_record_struct_name_prefix_invalid() -> None:
+    """An invalid struct-name prefix surfaces as a clean CLI error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "rust",
+            "-f",
+            "json",
+            "--heterogeneous-strategy",
+            "record",
+            "--record-struct-name-prefix",
+            "bad-name",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = (
+        "Error: record_struct_name_prefix 'bad-name' must be a PascalCase "
+        "identifier starting with an uppercase letter.\n"
+    )
+    assert result.output == expected
+
+
+def test_record_struct_name_prefix_unsupported_for_language() -> None:
+    """--record-struct-name-prefix rejects languages without the option."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "yaml",
+            "-f",
+            "json",
+            "--record-struct-name-prefix",
+            "Widget",
+        ],
+        input='{"a": 1}\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    expected_usage_error_exit_code = 2
+    assert result.exit_code == expected_usage_error_exit_code
+    expected = (
+        "Usage: literalize [OPTIONS]\n"
+        "Try 'literalize --help' for help.\n"
+        "\n"
+        "Error: --record-struct-name-prefix is not supported for "
+        "language 'yaml'.\n"
+    )
+    assert result.output == expected
+
+
+def test_tuple_arity_not_representable() -> None:
+    """A tuple arity with no native form surfaces as a clean CLI error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "kotlin",
+            "-f",
+            "json",
+            "--heterogeneous-strategy",
+            "tuple",
+        ],
+        input='[1, "a", true, 2, 3]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    expected = (
+        "Error: a heterogeneous scalar array of 5 elements has no native "
+        "fixed-size tuple in the target language\n"
     )
     assert result.output == expected
 

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -82,8 +82,8 @@ Options:
                                   specific). Choices: newline, none, semicolon.
   --heterogeneous-strategy TEXT   Heterogeneous-collection strategy (language-
                                   specific). Choices: error, interface,
-                                  object_variant, tagged_enum, union_type,
-                                  variant.
+                                  object_variant, record, tagged_enum, tuple,
+                                  union_type, variant.
   --call-style TEXT               Call style (language-specific). Choices:
                                   command, curried, keyword, named, object,
                                   positional, prefix, prefix_keyword.
@@ -92,12 +92,12 @@ Options:
   --language-version TEXT         Target language version (language-specific).
                                   Choices: ada_2022, ans, ansi, c99, cpp20,
                                   dev_2024, dotnet_6, edition_2021, es2015,
-                                  haskell_2010, ieee_1800_2017, jdk_11, otp_25,
-                                  py_3_12, r2022a, r7rs, sml_97, v0, v0_12,
-                                  v0_14, v0_15, v0_19, v0_20, v0_4, v1, v10,
-                                  v17, v1_11, v1_14, v1_18, v1_2, v1_9, v2,
-                                  v2002, v2003, v24_5, v3, v4, v5, v5_1, v5_36,
-                                  v5_4, v5_9, v6, v6d, v7, v8, v8_1, v8_6.
+                                  ghc2021, ieee_1800_2017, jdk_11, jdk_16,
+                                  otp_25, py38, py39, r2022a, r7rs, sml_97, v0,
+                                  v0_12, v0_14, v0_15, v0_19, v0_20, v0_4, v1,
+                                  v10, v17, v1_11, v1_14, v1_18, v1_2, v1_9, v2,
+                                  v2002, v2003, v2008, v24_5, v3, v4, v5, v5_1,
+                                  v5_36, v5_4, v5_9, v6d, v7, v8, v8_1, v8_6.
   --module-name TEXT              Module/namespace name for languages whose
                                   wrap-in-file form introduces a named scope
                                   (e.g. C, C++, D, Erlang, Fortran, F#, Java,
@@ -115,6 +115,12 @@ Options:
   --default-ordered-map-value-type TEXT
                                   Default type for ordered map values (language-
                                   specific, free-form string).
+  --record-struct-name-prefix TEXT
+                                  Name prefix for the structs/records generated
+                                  under --heterogeneous-strategy record
+                                  (language-specific, free-form string). Names
+                                  must be valid PascalCase identifiers for the
+                                  target language.
   --include-preamble / --no-include-preamble
                                   Include language preamble (e.g. package
                                   declarations, imports).

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.14.1"
+version = "2026.5.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -566,9 +566,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/a1/fa170c93be94154a1e686a4506f27b265f0738ced3e4ba9df720700310c0/literalizer-2026.5.14.1.tar.gz", hash = "sha256:0eaa0a28c13f50b43a606aba39e24300abffb434a78eb1bfb58803f5bcb0bf58", size = 2119815, upload-time = "2026-05-14T08:34:11.523Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2f/eca4642d193c0de5daef2f61b3f239106936de68b09f6563f083286381a7/literalizer-2026.5.17.tar.gz", hash = "sha256:e2fd8bc64eb11f115c540378de278664cd66f4e8ad68799172a6dfba77f17ff5", size = 2775902, upload-time = "2026-05-17T12:14:52.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/51/fc60f6ea5d34039c4469621ca4a49c0b4c5c47a1951dcc3f658cefc90342/literalizer-2026.5.14.1-py3-none-any.whl", hash = "sha256:ab0456b5b19a6d45e75a6c32691c31beb50270c8c5b1c0dd60c2204c07455cda", size = 558379, upload-time = "2026-05-14T08:34:09.923Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4c/fcd3e385b8a6ee378b8cb0fad4bc986fe6b295793905eb61a6457dd6cb24/literalizer-2026.5.17-py3-none-any.whl", hash = "sha256:ab98ceeb0da2ff0c63e830fdb9e24a2207c88bbfdbfe7fdda14e4ba0b408f4e1", size = 677480, upload-time = "2026-05-17T12:14:50.362Z" },
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ requires-dist = [
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
-    { name = "literalizer", specifier = "==2026.5.14.1" },
+    { name = "literalizer", specifier = "==2026.5.17" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },
@@ -1899,11 +1899,11 @@ wheels = [
 
 [[package]]
 name = "tomlkit"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `literalizer` 2026.5.14.1 → 2026.5.17 and removes the upstream-deleted `DottedCallStubNotSupportedError` / `FreeFunctionCallNotSupportedError` references that otherwise crash the CLI at import. Adds `--record-struct-name-prefix` for naming the structs/records the `record` heterogeneous strategy now generates across 14 languages, and surfaces the new `TupleArityNotRepresentableError` (via the new `tuple` strategy) and `InvalidRecordNameError` (invalid prefix) as clean CLI errors instead of tracebacks. Updates three tests affected by upstream behavior changes, adds coverage for the new option and errors, regenerates the help golden, and updates the changelog. All gates pass: ruff, mypy, pyright, ty, pyrefly, and 76 tests at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to an upstream `literalizer` version bump that changes available strategies/options and error types, affecting CLI behavior and output across multiple languages.
> 
> **Overview**
> Updates the CLI to `literalizer==2026.5.17`, dropping references to upstream-removed exceptions and syncing the lockfile.
> 
> Exposes new upstream heterogeneous features by surfacing `record`/`tuple` strategies where supported and adding `--record-struct-name-prefix` (validated per language) to control generated record/struct type names.
> 
> Improves error handling by mapping new upstream failures (`TupleArityNotRepresentableError`, `InvalidRecordNameError`) to clean Click errors instead of tracebacks, and updates/extends tests plus the help-text golden and changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cff04a44b91ed131fafed9387ebcff833421da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->