### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ ci:
     - shellcheck
     - shfmt
     - sphinx-lint
+    - strict-kwargs-fix
     - ty
     - uv-lock
     - yamlfix
@@ -158,6 +159,17 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: pyproject-fmt-fix
         name: pyproject-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,6 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.37",
     "uv==0.11.14",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "click>=8.3.0,<8.5.0",
     "literalizer==2026.5.17.1",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "furo==2025.12.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ optional-dependencies.dev = [
     "uv==0.11.14",
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
-
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.37",
     "uv==0.11.14",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "click>=8.3.0,<8.5.0",
     "literalizer==2026.5.17.1",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "furo==2025.12.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "click>=8.3.0,<8.5.0",
     "literalizer==2026.5.17.1",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "furo==2025.12.19",
@@ -65,6 +66,7 @@ optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "uv==0.11.14",
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
+
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
-    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18.post1" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.37" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.11.14" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -1847,15 +1847,15 @@ wheels = [
 
 [[package]]
 name = "strict-kwargs"
-version = "2026.5.18"
+version = "2026.5.18.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ty" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
-    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1b/748e7c411a22c26bd8488d4f7b25aaf72c72c2ed68a4e61f0fe802d02136/strict_kwargs-2026.5.18.post1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72241056a9bf0bfb9c522c5e888ef9868556fa2475890b90f29ae78b837eefb9", size = 2184045, upload-time = "2026-05-18T14:42:59.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/76/a3a6fa1082e30fdd8dee750bac496e1595d963e1155572e4ffb3f1cb3761/strict_kwargs-2026.5.18.post1-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:7dea7f9ba8557f57fbf56309735780c1d0b83627f237aeb77f1ee50b7020ac4c", size = 2294579, upload-time = "2026-05-18T14:43:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/62/75/15f0de12cf822ff2d1a098fdbe70d57c9d262868dfd728d5ea9cb3104234/strict_kwargs-2026.5.18.post1-py3-none-win_amd64.whl", hash = "sha256:eaad5813f39f338eaa3674aec6bf1463fc3ab2ce47f188262592486645d77132", size = 2069130, upload-time = "2026-05-18T14:43:03.323Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -605,6 +605,7 @@ dev = [
     { name = "sphinx-pyproject" },
     { name = "sphinx-substitution-extensions" },
     { name = "sphinxcontrib-spelling" },
+    { name = "strict-kwargs" },
     { name = "ty" },
     { name = "uv" },
     { name = "yamlfix" },
@@ -647,6 +648,7 @@ requires-dist = [
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.37" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.11.14" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -1841,6 +1843,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/cd/fa8039cedce6295644ff5f03367742d21e7922da426e8c666b7f5a213682/sphinxcontrib_spelling-8.0.2.tar.gz", hash = "sha256:afbc7b8e93721ab88f12bdd39d848b92017b3763b9ed6226b4b0e54b06664fea", size = 30955, upload-time = "2025-11-28T15:31:50.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/c5/bcd32aa919c9e1652cca5bed6478202656a320c407793b547f8c16c179e3/sphinxcontrib_spelling-8.0.2-py3-none-any.whl", hash = "sha256:db8b3b2945683d49e87a8a5133d2b8ed4206cb593038b986ca8686a485f9980d", size = 14587, upload-time = "2025-11-28T15:31:48.957Z" },
+]
+
+[[package]]
+name = "strict-kwargs"
+version = "2026.5.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ty" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (new pre-commit hook and dev dependency) and do not affect runtime code paths.
> 
> **Overview**
> Adds a new `strict-kwargs` pre-commit hook (`strict-kwargs-fix`) that runs `strict-kwargs fix` on Python files (serially) and is skipped in pre-commit CI.
> 
> Pins `strict-kwargs==2026.5.18.post1` in `pyproject.toml` dev extras and updates `uv.lock` to include the new package and metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9379dc576a4c536c236b3405dd8a9e6a2b086a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->