### PR TITLE
[codex] Drive changelog releases from towncrier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,38 +59,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the changelog underline
-        id: changelog_underline
-        run: |
-          underline="$(echo "${{ steps.calver.outputs.release }}" | tr -c '\n' '-')"
-          echo "underline=${underline}" >> "$GITHUB_OUTPUT"
+      # towncrier writes the rendered notes to stdout (informational
+      # chatter goes to stderr), so this is the curated release body for
+      # this version, not github-tag-action's commit-derived changelog.
+      - name: Generate the GitHub release notes
+        env:
+          RELEASE: ${{ steps.calver.outputs.release }}
+        run: uv run --extra=release towncrier build --draft --version "$RELEASE" >
+          release-notes.md
 
-      - name: Update changelog
-        id: update_changelog
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "Next\n----"
-          replace: |
-            Next
-            ----
-
-            ${{ steps.calver.outputs.release }}
-            ${{ steps.changelog_underline.outputs.underline }}
-          include: CHANGELOG.rst
-          regex: false
-
-      - name: Check changelog was modified
-        run: |
-          if [ "${{ steps.update_changelog.outputs.modifiedFiles }}" = "0" ]; then
-            echo "Error: No files were modified when updating changelog"
-            exit 1
-          fi
+      # Assemble the same fragments into CHANGELOG.rst under a new
+      # ``$RELEASE`` section and delete the consumed fragment files.
+      - name: Update the changelog
+        env:
+          RELEASE: ${{ steps.calver.outputs.release }}
+        run: uv run --extra=release towncrier build --yes --version "$RELEASE"
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
         with:
           commit_message: Bump CHANGELOG
-          file_pattern: CHANGELOG.rst
+          file_pattern: CHANGELOG.rst newsfragments
           # Error if there are no changes.
           skip_dirty_check: true
 
@@ -271,7 +260,7 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           makeLatest: true
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          bodyFile: release-notes.md
 
   publish-docker:
     name: Publish Docker image

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,36 +1,7 @@
 Changelog
 =========
 
-Next
-----
-
-- Bump ``literalizer`` to 2026.5.17.
-- Add ``--record-struct-name-prefix`` for naming the structs/records
-  that the ``record`` ``--heterogeneous-strategy`` generates (e.g.
-  ``Widget0``, ``Widget1`` instead of ``Record0``, ``Record1``).  The
-  ``record`` strategy is now available for many more languages in this
-  release (C, C#, C++, Crystal, D, Go, Java, Kotlin, Nim, Odin, Python,
-  Rust, Scala, Swift, V, Zig); the strategy and the new option are
-  surfaced automatically per language exactly like every other
-  language-specific option.
-- ``--heterogeneous-strategy tuple`` is now offered for the languages
-  that gained the upstream ``TUPLE`` strategy (C++, Kotlin, Rust,
-  Scala, TypeScript).  A tuple arity that has no native fixed-size
-  tuple in the target language (e.g. a 4+-element heterogeneous array
-  in Kotlin) now surfaces the new upstream
-  ``TupleArityNotRepresentableError`` as a clean CLI error rather than
-  a traceback.
-- An invalid ``--record-struct-name-prefix`` (not a PascalCase
-  identifier for the target language) now surfaces the upstream
-  ``InvalidRecordNameError`` as a clean CLI error rather than a
-  traceback.
-- ``literalizer`` removed ``DottedCallStubNotSupportedError`` and
-  ``FreeFunctionCallNotSupportedError`` (the context-aware
-  ``call_transform`` made them unreachable); they are no longer
-  referenced.  Languages whose declaration template previously only
-  wrapped literal values (Bash, Objective-C, Tcl, and others) now bind
-  a call result through their idiomatic call-binding form, so
-  ``--variable-name`` in ``--mode call`` works for them too.
+.. towncrier release notes start
 
 2026.05.14.1
 ------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,9 +20,18 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
+    "sphinxcontrib.towncrier.ext",
     "sphinx_click.ext",
     "sphinx_substitution_extensions",
 ]
+
+# Render the unreleased ``newsfragments/`` entries into
+# ``docs/source/unreleased.rst`` so the Sphinx spelling, doc-build and
+# link-checking gates cover the prose before it is assembled into
+# CHANGELOG.rst at release time.
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = f"{_pyproject_file.parent}"
 
 templates_path = ["_templates"]
 source_suffix = ".rst"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,4 +37,5 @@ Reference
    commands
    contributing
    release-process
+   unreleased
    changelog

--- a/docs/source/unreleased.rst
+++ b/docs/source/unreleased.rst
@@ -1,0 +1,8 @@
+Unreleased changes
+==================
+
+Changes that have landed on the main branch but are not yet part of a
+tagged release.  These entries are assembled into the
+:doc:`changelog` when the next release is published.
+
+.. towncrier-draft-entries::

--- a/docs/towncrier_template.rst.jinja
+++ b/docs/towncrier_template.rst.jinja
@@ -1,0 +1,14 @@
+
+{% for section_name, section in sections.items() %}
+{% if section %}
+{% for category, entries in section.items() %}
+{% for text, _ in entries.items() %}
+- {{ text }}
+
+{% endfor %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/newsfragments/+migrated-next-2.change.rst
+++ b/newsfragments/+migrated-next-2.change.rst
@@ -1,0 +1,8 @@
+Add ``--record-struct-name-prefix`` for naming the structs/records
+that the ``record`` ``--heterogeneous-strategy`` generates (e.g.
+``Widget0``, ``Widget1`` instead of ``Record0``, ``Record1``).  The
+``record`` strategy is now available for many more languages in this
+release (C, C#, C++, Crystal, D, Go, Java, Kotlin, Nim, Odin, Python,
+Rust, Scala, Swift, V, Zig); the strategy and the new option are
+surfaced automatically per language exactly like every other
+language-specific option.

--- a/newsfragments/+migrated-next-3.change.rst
+++ b/newsfragments/+migrated-next-3.change.rst
@@ -1,0 +1,7 @@
+``--heterogeneous-strategy tuple`` is now offered for the languages
+that gained the upstream ``TUPLE`` strategy (C++, Kotlin, Rust,
+Scala, TypeScript).  A tuple arity that has no native fixed-size
+tuple in the target language (e.g. a 4+-element heterogeneous array
+in Kotlin) now surfaces the new upstream
+``TupleArityNotRepresentableError`` as a clean CLI error rather than
+a traceback.

--- a/newsfragments/+migrated-next-4.change.rst
+++ b/newsfragments/+migrated-next-4.change.rst
@@ -1,0 +1,4 @@
+An invalid ``--record-struct-name-prefix`` (not a PascalCase
+identifier for the target language) now surfaces the upstream
+``InvalidRecordNameError`` as a clean CLI error rather than a
+traceback.

--- a/newsfragments/+migrated-next-5.change.rst
+++ b/newsfragments/+migrated-next-5.change.rst
@@ -1,0 +1,7 @@
+``literalizer`` removed ``DottedCallStubNotSupportedError`` and
+``FreeFunctionCallNotSupportedError`` (the context-aware
+``call_transform`` made them unreachable); they are no longer
+referenced.  Languages whose declaration template previously only
+wrapped literal values (Bash, Objective-C, Tcl, and others) now bind
+a call result through their idiomatic call-binding form, so
+``--variable-name`` in ``--mode call`` works for them too.

--- a/newsfragments/+migrated-next.change.rst
+++ b/newsfragments/+migrated-next.change.rst
@@ -1,0 +1,1 @@
+Bump ``literalizer`` to 2026.5.17.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,11 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    # ``sphinxcontrib-towncrier`` renders unreleased news fragments
+    # into docs/source/unreleased.rst during Sphinx builds.
+    "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.19.post3",
+    "towncrier==25.8.0",
     "ty==0.0.38",
     "uv==0.11.15",
     "vulture==2.16",
@@ -258,6 +262,8 @@ ignore = [
     ".pre-commit-config.yaml",
     ".vscode/**",
     "CHANGELOG.rst",
+    "newsfragments",
+    "newsfragments/**",
     "Dockerfile",
     "LICENSE",
     "Makefile",
@@ -341,6 +347,30 @@ report.exclude_also = [
 ]
 report.show_missing = true
 
+[tool.towncrier]
+# The changelog and the per-release GitHub release notes are both built
+# from news fragments under ``newsfragments/``.  The release workflow
+# runs ``towncrier build`` to assemble them; contributors add one
+# fragment file per user-facing change.
+directory = "newsfragments"
+filename = "CHANGELOG.rst"
+# Custom template so an assembled version reproduces the historical
+# style exactly: a bare ``<version>`` heading (no project name, no
+# date) followed by a flat bullet list with no per-type sub-headings.
+template = "docs/towncrier_template.rst.jinja"
+title_format = "{version}"
+# ``title_format`` underline first, then any nested headings.  A bare
+# version such as ``2026.05.18`` underlined with ``-`` matches every
+# pre-towncrier entry in CHANGELOG.rst.
+underlines = [ "-", "~", "^" ]
+issue_format = "#{issue}"
+type = [
+    # A single, unnamed fragment type keeps the assembled output as one
+    # flat bullet list, matching the historical changelog (which never
+    # grouped entries under "Features"/"Bugfixes"/... sub-headings).
+    { directory = "change", name = "", showcontent = true },
+]
+
 [tool.doc8]
 max_line_length = 2000
 ignore_path = [
@@ -395,6 +425,9 @@ ignore_names = [
     "spelling_word_list_filename",
     "templates_path",
     "warning_is_error",
+    "towncrier_draft_autoversion_mode",
+    "towncrier_draft_include_empty",
+    "towncrier_draft_working_directory",
 ]
 exclude = [
     ".venv",

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,9 @@ dev = [
     { name = "sphinx-pyproject" },
     { name = "sphinx-substitution-extensions" },
     { name = "sphinxcontrib-spelling" },
+    { name = "sphinxcontrib-towncrier" },
     { name = "strict-kwargs" },
+    { name = "towncrier" },
     { name = "ty" },
     { name = "uv" },
     { name = "vulture" },
@@ -732,7 +734,9 @@ requires-dist = [
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
+    { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.19.post3" },
+    { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.11.15" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
@@ -2048,6 +2052,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-towncrier"
+version = "0.5.0a0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+    { name = "towncrier" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/fe/72ed57093e28af10595c50839b183c5fdf0952482e9ef0ca6eb90eb85c5d/sphinxcontrib_towncrier-0.5.0a0.tar.gz", hash = "sha256:294e69df6e275e7a86df7ea6a927cc7c28c2c370a884cd5c45de6ec989858f27", size = 62453, upload-time = "2025-02-28T01:59:16.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/5c/f7e39f243636a5e1894f2f5a72579977bf3968922afdb75175ee45062066/sphinxcontrib_towncrier-0.5.0a0-py3-none-any.whl", hash = "sha256:11d130c3ad5e4649821d543c4ea7ab64bbe78df4d859ef94f4298e7845dc0f59", size = 12609, upload-time = "2025-02-28T01:59:15.178Z" },
+]
+
+[[package]]
 name = "stevedore"
 version = "5.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2139,6 +2156,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "towncrier"
+version = "25.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/eb/5bf25a34123698d3bbab39c5bc5375f8f8bcbcc5a136964ade66935b8b9d/towncrier-25.8.0.tar.gz", hash = "sha256:eef16d29f831ad57abb3ae32a0565739866219f1ebfbdd297d32894eb9940eb1", size = 76322, upload-time = "2025-08-30T11:41:55.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/06/8ba22ec32c74ac1be3baa26116e3c28bc0e76a5387476921d20b6fdade11/towncrier-25.8.0-py3-none-any.whl", hash = "sha256:b953d133d98f9aeae9084b56a3563fd2519dfc6ec33f61c9cd2c61ff243fb513", size = 65101, upload-time = "2025-08-30T11:41:53.644Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This switches release changelog handling to the same towncrier-based flow used by literalizer:

- replace the manual `Next` changelog section update with `towncrier build`
- generate GitHub release notes from the same news fragments
- add the towncrier config, template, and `newsfragments/` directory
- render unreleased fragments in docs where the project has Sphinx docs
- migrate any existing `Next` entries into initial news fragments

## Validation

- `uv run --extra=release towncrier build --draft --version 2099.01.01`
- `uvx --from actionlint-py actionlint .github/workflows/release.yml`
- `uv run --extra=dev pyproject-fmt --check --no-print-diff pyproject.toml` where the repo has a dev extra
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow and documentation build to generate both GitHub release notes and `CHANGELOG.rst` from towncrier fragments; mistakes could lead to missing/incorrect release notes or changelog updates during publishing.
> 
> **Overview**
> Switches releases from a manually-maintained `CHANGELOG.rst` “Next” section to a towncrier-driven flow using `newsfragments/` as the single source of truth.
> 
> The GitHub Actions release workflow now runs `towncrier build` to (1) generate curated GitHub release notes into `release-notes.md` and (2) update `CHANGELOG.rst`, committing both the changelog and consumed fragments; the release action uses `bodyFile` instead of commit-derived changelog text.
> 
> Docs now include an *Unreleased changes* page rendered from fragments via `sphinxcontrib-towncrier`, and the repo adds towncrier config/template plus initial migrated fragment files; dependencies/lockfile are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01859575f2180a332a31dbee9c92fba8d5e4be6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->