### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ optional-dependencies.release = [
     # homebrew-pypi-poet uses pkg_resources, which was removed in
     # setuptools 82.
     "setuptools>=70,<83",
+    "towncrier==25.8.0",
 ]
 urls.Documentation = "https://adamtheturtle.github.io/literalizer-cli/"
 urls.Source = "https://github.com/adamtheturtle/literalizer-cli"

--- a/uv.lock
+++ b/uv.lock
@@ -693,6 +693,7 @@ release = [
     { name = "check-wheel-contents" },
     { name = "homebrew-pypi-poet" },
     { name = "setuptools" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -737,6 +738,7 @@ requires-dist = [
     { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.19.post3" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
+    { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.11.15" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency-only change to ensure release jobs can run `towncrier`, with no runtime or logic changes.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency extra so release workflows that install only `--extra=release` can run `towncrier build`.
> 
> Updates `uv.lock` accordingly to include `towncrier` in the `release` dependency group and `requires-dist` metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bc469551b7130085d5060cf06fa6c1e5c00970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->