### PR TITLE
Bump literalizer to 2026.7.24.1

### DIFF
--- a/newsfragments/446.change.rst
+++ b/newsfragments/446.change.rst
@@ -1,0 +1,6 @@
+Bump ``literalizer`` to 2026.7.24.1.  The CLI now offers C++14, C++17, and
+C++20 through ``--language-version`` and exposes generated heterogeneous-value
+carrier names through ``--heterogeneous-value-variant-name``.  The release also
+adopts upstream fixes for RECORD shape inference, null-byte strings, empty
+containers, wide integers, and variable-name validation; invalid or reserved new
+variable names are surfaced as clean CLI errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.5.0",
-    "literalizer==2026.7.15",
+    "literalizer==2026.7.24.1",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -106,6 +106,9 @@ _OPTION_SUPPORT_FLAG: dict[str, Callable[[LanguageCls], bool]] = {
     "record_struct_name_prefix": (
         lambda cls: cls.supports_record_struct_name_prefix
     ),
+    "heterogeneous_value_variant_name": (
+        lambda cls: "heterogeneous_value_variant_name" in cls.__dict__
+    ),
 }
 
 
@@ -288,6 +291,7 @@ _STRING_OPTIONS: frozenset[str] = frozenset(
         "default_ordered_map_value_type",
         "module_name",
         "record_struct_name_prefix",
+        "heterogeneous_value_variant_name",
     },
 )
 
@@ -341,6 +345,8 @@ _LITERALIZER_EXCEPTIONS = (
     literalizer.exceptions.WrapCombinedInFileNotSupportedError,
     literalizer.exceptions.DottedCallTargetNotSupportedError,
     literalizer.exceptions.CallArgNotSupportedError,
+    literalizer.exceptions.ReservedVariableNameError,
+    literalizer.exceptions.InvalidNewVariableNameError,
 )
 
 
@@ -624,6 +630,14 @@ def literalize_call_input(
     ),
 )
 @click.option(
+    "--heterogeneous-value-variant-name",
+    default=None,
+    help=(
+        "Name for a generated heterogeneous-value carrier"
+        " (language-specific, free-form string)."
+    ),
+)
+@click.option(
     "--include-preamble/--no-include-preamble",
     default=False,
     help="Include language preamble (e.g. package declarations, imports).",
@@ -711,6 +725,7 @@ def main(
     default_set_element_type: str | None,
     default_ordered_map_value_type: str | None,
     record_struct_name_prefix: str | None,
+    heterogeneous_value_variant_name: str | None,
     include_preamble: bool,
     mode: str,
     call_function: str | None,
@@ -775,6 +790,7 @@ def main(
         "default_ordered_map_value_type": default_ordered_map_value_type,
         "module_name": module_name,
         "record_struct_name_prefix": record_struct_name_prefix,
+        "heterogeneous_value_variant_name": heterogeneous_value_variant_name,
     }
     for option_name, value in cli_string_options.items():
         if value is not None:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -1767,6 +1767,92 @@ def test_record_struct_name_prefix_unsupported_for_language() -> None:
     assert result.output == expected
 
 
+def test_cpp14_heterogeneous_value_variant_name() -> None:
+    """C++14 carriers can be named through the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "cpp",
+            "-f",
+            "json",
+            "--language-version",
+            "cpp14",
+            "--heterogeneous-strategy",
+            "error",
+            "--heterogeneous-value-variant-name",
+            "DynamicValue",
+            "--include-preamble",
+        ],
+        input='[1, "a"]\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, result.output
+    assert "struct DynamicValue {" in result.output
+    assert "std::vector<DynamicValue>{" in result.output
+
+
+def test_heterogeneous_value_variant_name_unsupported() -> None:
+    """Carrier names reject languages without the constructor option."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--heterogeneous-value-variant-name",
+            "Value",
+        ],
+        input="1\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    expected_usage_error_exit_code = 2
+    assert result.exit_code == expected_usage_error_exit_code
+    assert result.output.endswith(
+        "Error: --heterogeneous-value-variant-name is not supported for "
+        "language 'python'.\n"
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=("variable_name", "reason"),
+    argvalues=[
+        ("class", "it is a reserved identifier"),
+        ("bad-name", "it is not a valid identifier"),
+    ],
+)
+def test_invalid_new_variable_name(
+    variable_name: str,
+    reason: str,
+) -> None:
+    """Invalid new variable names surface as clean CLI errors."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--variable-name",
+            variable_name,
+        ],
+        input="1\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert result.output == (
+        f"Error: Python cannot use NewVariable name {variable_name!r}: "
+        f"{reason}\n"
+    )
+
+
 def test_tuple_arity_not_representable() -> None:
     """A tuple arity with no native form surfaces as a clean CLI error."""
     runner = CliRunner()

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -90,14 +90,15 @@ Options:
   --numeric-style TEXT            Numeric style (language-specific). Choices:
                                   explicit, overloaded.
   --language-version TEXT         Target language version (language-specific).
-                                  Choices: ada_2022, ans, ansi, c99, cpp20,
-                                  dev_2024, dotnet_6, edition_2021, es2015,
-                                  ghc2021, ieee_1800_2017, jdk_11, jdk_16,
-                                  otp_25, py38, py39, r2022a, r7rs, sml_97, v0,
-                                  v0_12, v0_14, v0_15, v0_19, v0_20, v0_4, v1,
-                                  v10, v17, v1_11, v1_14, v1_18, v1_2, v1_9, v2,
-                                  v2002, v2003, v2008, v24_5, v3, v4, v5, v5_1,
-                                  v5_36, v5_4, v5_9, v6d, v7, v8, v8_1, v8_6.
+                                  Choices: ada_2022, ans, ansi, c99, cpp14,
+                                  cpp17, cpp20, dev_2024, dotnet_6,
+                                  edition_2021, es2015, ghc2021, ieee_1800_2017,
+                                  jdk_11, jdk_16, otp_25, py38, py39, r2022a,
+                                  r7rs, sml_97, v0, v0_12, v0_14, v0_15, v0_19,
+                                  v0_20, v0_4, v1, v10, v17, v1_11, v1_14,
+                                  v1_18, v1_2, v1_9, v2, v2002, v2003, v2008,
+                                  v24_5, v3, v4, v5, v5_1, v5_36, v5_4, v5_9,
+                                  v6d, v7, v8, v8_1, v8_6.
   --module-name TEXT              Module/namespace name for languages whose
                                   wrap-in-file form introduces a named scope
                                   (e.g. C, C++, D, Erlang, Fortran, F#, Java,
@@ -121,6 +122,9 @@ Options:
                                   (language-specific, free-form string). Names
                                   must be valid PascalCase identifiers for the
                                   target language.
+  --heterogeneous-value-variant-name TEXT
+                                  Name for a generated heterogeneous-value
+                                  carrier (language-specific, free-form string).
   --include-preamble / --no-include-preamble
                                   Include language preamble (e.g. package
                                   declarations, imports).

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.15"
+version = "2026.7.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -638,9 +638,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/32/96794276d13893ab58998f416fdf8ffd033b274960f761157542db9d5025/literalizer-2026.7.15.tar.gz", hash = "sha256:88654b090818d99fee74611dd5cd8cb20057432a8eb597ed75e51df969642ff7", size = 3406050, upload-time = "2026-07-15T14:01:42.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/2a/4474e7f5be258a3d71e203a51f04458b9f6b550044b643d312ba97f33a2e/literalizer-2026.7.24.1.tar.gz", hash = "sha256:2654a5bb96239682d8b907673d862af5da5354deef9e48ae1f7377992a68ee69", size = 3689365, upload-time = "2026-07-24T13:53:50.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/59/6e4506d41b683613111fe066179d003ff28fe03f9f0a16e983e0fcc929d8/literalizer-2026.7.15-py3-none-any.whl", hash = "sha256:fe1b23cd03faa18d545a753ce4fb4243ef448b9f7aa8cde3e51bc9fa2c049feb", size = 991375, upload-time = "2026-07-15T14:01:40.088Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a2/f5e273dd38ac3fb00daa7a1f48c611dd4e833685604c6691f874364ab10c/literalizer-2026.7.24.1-py3-none-any.whl", hash = "sha256:800aca0c1e686d8f1ec754478051cf9daf7f2bc3359a2aaa3fa120e77ba91a26", size = 848800, upload-time = "2026-07-24T13:53:48.323Z" },
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.15" },
+    { name = "literalizer", specifier = "==2026.7.24.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.10" },


### PR DESCRIPTION
Bump `literalizer` from 2026.7.15 to 2026.7.24.1 and refresh the lockfile. Expose the new C++14/17/20 targets through the existing `--language-version` option and add `--heterogeneous-value-variant-name` for generated carriers. Surface the upstream reserved and invalid new-variable-name errors as clean CLI failures, while adopting the upstream rendering fixes included in the release. Update CLI/help regression coverage and add a release fragment; validated with 80 tests at 100% coverage plus all pre-commit, pre-push, manual, typing, linting, documentation, spelling, and link checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency pin plus additive CLI options and exception mapping; rendering behavior changes come from the upstream release, covered by existing and new tests.
> 
> **Overview**
> Upgrades **literalizer** to `2026.7.24.1` (lockfile and news fragment) and wires new upstream capabilities into the CLI.
> 
> Adds **`--heterogeneous-value-variant-name`** for languages that support it (e.g. C++ with `--language-version cpp14`), with the same per-language validation as other string options. **`--language-version`** help now lists **cpp14** and **cpp17** alongside cpp20. **`ReservedVariableNameError`** and **`InvalidNewVariableNameError`** are mapped to user-facing CLI errors instead of tracebacks.
> 
> Tests and the help regression snapshot cover the new flag, unsupported languages, and invalid `--variable-name` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4462377fc52eefc9f30fcbc0f3aa7406ee4fe0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->