### PR TITLE
Expose Python union format options

### DIFF
--- a/newsfragments/459.change.rst
+++ b/newsfragments/459.change.rst
@@ -1,0 +1,1 @@
+Expose Python annotation evaluation and union format options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.5.0",
-    "literalizer==2026.7.24.2",
+    "literalizer==2026.7.29.1",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -51,10 +51,7 @@ def _language_owned_enum(
     *, lang_cls: LanguageCls, name: str
 ) -> type[enum.Enum]:
     """Return an enum defined only by a particular language class."""
-    enum_cls = vars(lang_cls)[name]
-    if not isinstance(enum_cls, type) or not issubclass(enum_cls, enum.Enum):
-        msg = f"{lang_cls.__name__}.{name} is not an enum"
-        raise TypeError(msg)
+    enum_cls: type[enum.Enum] = vars(lang_cls)[name]
     return enum_cls
 
 

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -46,6 +46,18 @@ _REF_CASE_MAP: dict[str, IdentifierCase] = {
     member.name.lower(): member for member in IdentifierCase
 }
 
+
+def _language_owned_enum(
+    *, lang_cls: LanguageCls, name: str
+) -> type[enum.Enum]:
+    """Return an enum defined only by a particular language class."""
+    enum_cls = vars(lang_cls)[name]
+    if not isinstance(enum_cls, type) or not issubclass(enum_cls, enum.Enum):
+        msg = f"{lang_cls.__name__}.{name} is not an enum"
+        raise TypeError(msg)
+    return enum_cls
+
+
 # Map from CLI option name to a getter for the enum class.
 _OPTION_TO_ENUM: dict[str, Callable[[LanguageCls], type[enum.Enum]]] = {
     "sequence_format": lambda cls: cls.SequenceFormats,
@@ -70,6 +82,14 @@ _OPTION_TO_ENUM: dict[str, Callable[[LanguageCls], type[enum.Enum]]] = {
     "call_style": lambda cls: cls.CallStyles,
     "numeric_style": lambda cls: cls.NumericStyles,
     "language_version": lambda cls: cls.VersionFormats,
+    "annotation_evaluation": lambda cls: _language_owned_enum(
+        lang_cls=cls,
+        name="AnnotationEvaluations",
+    ),
+    "union_format": lambda cls: _language_owned_enum(
+        lang_cls=cls,
+        name="UnionFormats",
+    ),
 }
 
 
@@ -109,6 +129,8 @@ _OPTION_SUPPORT_FLAG: dict[str, Callable[[LanguageCls], bool]] = {
     "heterogeneous_value_variant_name": (
         lambda cls: "heterogeneous_value_variant_name" in cls.__dict__
     ),
+    "annotation_evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
+    "union_format": lambda cls: "UnionFormats" in vars(cls),
 }
 
 
@@ -230,6 +252,14 @@ _NUMERIC_STYLE_HELP = _choices_help(
 _LANGUAGE_VERSION_HELP = _choices_help(
     label="Target language version",
     option_name="language_version",
+)
+_ANNOTATION_EVALUATION_HELP = _choices_help(
+    label="Annotation evaluation",
+    option_name="annotation_evaluation",
+)
+_UNION_FORMAT_HELP = _choices_help(
+    label="Union annotation format",
+    option_name="union_format",
 )
 
 
@@ -576,6 +606,16 @@ def literalize_call_input(
     help=_LANGUAGE_VERSION_HELP,
 )
 @click.option(
+    "--annotation-evaluation",
+    default=None,
+    help=_ANNOTATION_EVALUATION_HELP,
+)
+@click.option(
+    "--union-format",
+    default=None,
+    help=_UNION_FORMAT_HELP,
+)
+@click.option(
     "--module-name",
     default=None,
     help=(
@@ -718,6 +758,8 @@ def main(
     call_style: str | None,
     numeric_style: str | None,
     language_version: str | None,
+    annotation_evaluation: str | None,
+    union_format: str | None,
     module_name: str | None,
     default_dict_key_type: str | None,
     default_dict_value_type: str | None,
@@ -762,6 +804,8 @@ def main(
         "call_style": call_style,
         "numeric_style": numeric_style,
         "language_version": language_version,
+        "annotation_evaluation": annotation_evaluation,
+        "union_format": union_format,
     }
     for option_name, value in cli_language_options.items():
         if value is not None:

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -1979,3 +1979,38 @@ def test_wrap_in_file() -> None:
     assert result.exit_code == 0
     assert "package main" in result.output
     assert "data" in result.output
+
+
+def test_python_union_format() -> None:
+    """Python annotation and union options reach literalizer."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "--language",
+            "python",
+            "--input-format",
+            "yaml",
+            "--variable-name",
+            "my_data",
+            "--wrap-in-file",
+            "--variable-type-hints",
+            "always",
+            "--annotation-evaluation",
+            "postponed",
+            "--union-format",
+            "typing",
+        ],
+        input="- hello\n- 42\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert result.output == (
+        "from __future__ import annotations\n"
+        "from typing import Union\n"
+        "my_data: tuple[Union[str, int], ...] = (\n"
+        '    "hello",\n'
+        "    42,\n"
+        ")\n"
+    )

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -99,6 +99,10 @@ Options:
                                   v1_18, v1_2, v1_9, v2, v2002, v2003, v2008,
                                   v24_5, v3, v4, v5, v5_1, v5_36, v5_4, v5_9,
                                   v6d, v7, v8, v8_1, v8_6.
+  --annotation-evaluation TEXT    Annotation evaluation (language-specific).
+                                  Choices: eager, postponed.
+  --union-format TEXT             Union annotation format (language-specific).
+                                  Choices: auto, pipe, typing.
   --module-name TEXT              Module/namespace name for languages whose
                                   wrap-in-file form introduces a named scope
                                   (e.g. C, C++, D, Erlang, Fortran, F#, Java,

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.24.2"
+version = "2026.7.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -638,9 +638,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/a8/f73b6d4d974593059ec015a6f9b67faac1e57caf1ace397bc6a556a0e923/literalizer-2026.7.24.2.tar.gz", hash = "sha256:5dc07dd31a445c4f3461ce5cf7336d27fbb54d642001bd20bdfdb824283372dc", size = 3704908, upload-time = "2026-07-24T16:33:30.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/22/b18e6e83cb01f961e6d06636449fc4719307020d615d02d91009fed558a7/literalizer-2026.7.29.1.tar.gz", hash = "sha256:cbde328bf9cdb60587252fa25977213c01be2a19d5339eb55ab24dd2837c4318", size = 3761548, upload-time = "2026-07-29T16:46:26.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/02/aecd9e0d2800a2cef197a378687016c0e821d6e25bbe3cb0f02e96d19b52/literalizer-2026.7.24.2-py3-none-any.whl", hash = "sha256:c240b4b5e9847a38b040ac6d131eeae1ebfd5d307d81ff6bff1b63e6767c2e2e", size = 848985, upload-time = "2026-07-24T16:33:28.247Z" },
+    { url = "https://files.pythonhosted.org/packages/07/75/cbab2ad244a5cafed0f4278f15e20f152b75399b70a5c8179b5d2c9e9461/literalizer-2026.7.29.1-py3-none-any.whl", hash = "sha256:fa7ff45e0c2d934c97587517a20bfd221834fcb19b543ae14903b61588de4e7e", size = 853699, upload-time = "2026-07-29T16:46:23.76Z" },
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.24.2" },
+    { name = "literalizer", specifier = "==2026.7.29.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.11" },


### PR DESCRIPTION
Fixes #459.

- bump literalizer to 2026.7.29.1
- expose `--annotation-evaluation` and `--union-format` for languages that own those enums
- update CLI help and add end-to-end `typing.Union` coverage

Validation:
- `uv run --extra dev pytest -q` (81 passed)
- `uv run --extra dev prek run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Incremental CLI option plumbing on the same path as other language enums, with tests and a routine dependency bump; no auth or data-handling changes.
> 
> **Overview**
> Adds **`--annotation-evaluation`** and **`--union-format`** so users can control Python type-hint output (e.g. postponed annotations and `typing.Union` vs pipe unions) from the CLI.
> 
> The wiring follows existing language-specific enum options: a small **`_language_owned_enum`** helper resolves enums that only exist on some language classes, and support checks reject these flags for languages that do not define `AnnotationEvaluations` / `UnionFormats`. **`literalizer`** is bumped to **2026.7.29.1**, with help text, a news fragment, and an end-to-end test asserting `from __future__ import annotations` and `tuple[Union[str, int], ...]` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb95bf06d5a16c955288e3fa471a472daf51f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->