### PR TITLE
Bump literalizer to 2026.8.2 and expose multiline strings

### DIFF
--- a/newsfragments/+bump-literalizer-2026-8-2.change.rst
+++ b/newsfragments/+bump-literalizer-2026-8-2.change.rst
@@ -1,0 +1,4 @@
+Bump ``literalizer`` to 2026.8.2.  Native multiline string formats are now
+available through ``--string-format multiline`` for supported languages, and
+``--multiline-raw-string-delimiter-base`` configures fallback delimiters for C++
+raw strings.  Invalid C++ delimiter bases are surfaced as clean CLI errors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "click>=8.3.0,<8.5.0",
-    "literalizer==2026.7.29.1",
+    "literalizer==2026.8.2",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -51,6 +51,7 @@ macOS
 matlab
 Mojo
 mojo
+multiline
 mut
 namespace
 natively

--- a/src/literalizer_cli/__init__.py
+++ b/src/literalizer_cli/__init__.py
@@ -126,6 +126,9 @@ _OPTION_SUPPORT_FLAG: dict[str, Callable[[LanguageCls], bool]] = {
     "heterogeneous_value_variant_name": (
         lambda cls: "heterogeneous_value_variant_name" in cls.__dict__
     ),
+    "multiline_raw_string_delimiter_base": (
+        lambda cls: "multiline_raw_string_delimiter_base" in cls.__dict__
+    ),
     "annotation_evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
     "union_format": lambda cls: "UnionFormats" in vars(cls),
 }
@@ -319,6 +322,7 @@ _STRING_OPTIONS: frozenset[str] = frozenset(
         "module_name",
         "record_struct_name_prefix",
         "heterogeneous_value_variant_name",
+        "multiline_raw_string_delimiter_base",
     },
 )
 
@@ -675,6 +679,14 @@ def literalize_call_input(
     ),
 )
 @click.option(
+    "--multiline-raw-string-delimiter-base",
+    default=None,
+    help=(
+        "Fallback delimiter base for C++ multiline raw strings"
+        " (language-specific, free-form string)."
+    ),
+)
+@click.option(
     "--include-preamble/--no-include-preamble",
     default=False,
     help="Include language preamble (e.g. package declarations, imports).",
@@ -765,6 +777,7 @@ def main(
     default_ordered_map_value_type: str | None,
     record_struct_name_prefix: str | None,
     heterogeneous_value_variant_name: str | None,
+    multiline_raw_string_delimiter_base: str | None,
     include_preamble: bool,
     mode: str,
     call_function: str | None,
@@ -832,6 +845,9 @@ def main(
         "module_name": module_name,
         "record_struct_name_prefix": record_struct_name_prefix,
         "heterogeneous_value_variant_name": heterogeneous_value_variant_name,
+        "multiline_raw_string_delimiter_base": (
+            multiline_raw_string_delimiter_base
+        ),
     }
     for option_name, value in cli_string_options.items():
         if value is not None:
@@ -849,7 +865,10 @@ def main(
 
     try:
         lang_instance = lang_cls(indent=indent, **lang_kwargs)
-    except literalizer.exceptions.InvalidRecordNameError as exc:
+    except (
+        literalizer.exceptions.InvalidCppRawStringDelimiterError,
+        literalizer.exceptions.InvalidRecordNameError,
+    ) as exc:
         raise click.ClickException(message=str(object=exc)) from None
 
     variable_form: VariableForm | None = None

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -567,7 +567,7 @@ def test_sequence_format() -> None:
 
 
 def test_multiline_string_format_with_cpp_delimiter_base() -> None:
-    """C++ multiline strings use the configured delimiter after a
+    """C++ multi-line strings use the configured delimiter after a
     collision.
     """
     runner = CliRunner()

--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -566,6 +566,81 @@ def test_sequence_format() -> None:
     assert result.output == expected
 
 
+def test_multiline_string_format_with_cpp_delimiter_base() -> None:
+    """C++ multiline strings use the configured delimiter after a
+    collision.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "cpp",
+            "-f",
+            "json",
+            "--string-format",
+            "multiline",
+            "--multiline-raw-string-delimiter-base",
+            "custom",
+        ],
+        input=r'"first )\"\nsecond"' "\n",
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert result.output == 'R"custom(first )"\nsecond)custom"\n'
+
+
+def test_invalid_cpp_multiline_raw_string_delimiter_base() -> None:
+    """Invalid C++ raw-string delimiter bases are clean CLI errors."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "cpp",
+            "-f",
+            "json",
+            "--multiline-raw-string-delimiter-base",
+            "bad delimiter",
+        ],
+        input='"value"\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 1
+    assert result.output == (
+        "Error: Cpp multiline_raw_string_delimiter_base 'bad delimiter' is "
+        "invalid: these characters are not permitted by C++'s raw-string "
+        "delimiter grammar: [' ']\n"
+    )
+
+
+def test_cpp_multiline_raw_string_delimiter_base_unsupported() -> None:
+    """The C++ delimiter option rejects unsupported languages."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "-l",
+            "python",
+            "-f",
+            "json",
+            "--multiline-raw-string-delimiter-base",
+            "custom",
+        ],
+        input='"value"\n',
+        catch_exceptions=False,
+        color=True,
+    )
+    expected_usage_error_exit_code = 2
+    assert result.exit_code == expected_usage_error_exit_code
+    assert (
+        "--multiline-raw-string-delimiter-base is not supported for "
+        "language 'python'" in result.output
+    )
+
+
 def test_set_format() -> None:
     """--set-format changes the set representation."""
     runner = CliRunner()

--- a/tests/test_literalizer_cli/test_help.txt
+++ b/tests/test_literalizer_cli/test_help.txt
@@ -71,8 +71,8 @@ Options:
   --numeric-separator TEXT        Numeric separator (language-specific).
                                   Choices: none, underscore.
   --string-format TEXT            String format (language-specific). Choices:
-                                  double, double_utf8, escaped, explicit, raw,
-                                  single, verbatim.
+                                  double, double_utf8, escaped, explicit,
+                                  multiline, raw, single, verbatim.
   --trailing-comma TEXT           Trailing comma (language-specific). Choices:
                                   no, yes.
   --empty-dict-key TEXT           Empty dict key handling (language-specific).
@@ -129,6 +129,9 @@ Options:
   --heterogeneous-value-variant-name TEXT
                                   Name for a generated heterogeneous-value
                                   carrier (language-specific, free-form string).
+  --multiline-raw-string-delimiter-base TEXT
+                                  Fallback delimiter base for C++ multiline raw
+                                  strings (language-specific, free-form string).
   --include-preamble / --no-include-preamble
                                   Include language preamble (e.g. package
                                   declarations, imports).

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.29.1"
+version = "2026.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -638,9 +638,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/22/b18e6e83cb01f961e6d06636449fc4719307020d615d02d91009fed558a7/literalizer-2026.7.29.1.tar.gz", hash = "sha256:cbde328bf9cdb60587252fa25977213c01be2a19d5339eb55ab24dd2837c4318", size = 3761548, upload-time = "2026-07-29T16:46:26.034Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/6a/9dbadcf45a71a496e20211021d824a6a5cc13bc4ff433faaf71331ef6e36/literalizer-2026.8.2.tar.gz", hash = "sha256:e84374c53b465bf53e7c4a9381c50c866f7bd9d00ea7628ac81ed53c4f742c71", size = 3771422, upload-time = "2026-08-02T08:56:57.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/75/cbab2ad244a5cafed0f4278f15e20f152b75399b70a5c8179b5d2c9e9461/literalizer-2026.7.29.1-py3-none-any.whl", hash = "sha256:fa7ff45e0c2d934c97587517a20bfd221834fcb19b543ae14903b61588de4e7e", size = 853699, upload-time = "2026-07-29T16:46:23.76Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4e/41e87d9677932d54e53192729a1bea84bb1d9c8ba389eaa8854dc9ecb8ef/literalizer-2026.8.2-py3-none-any.whl", hash = "sha256:ecdc5cefd69e33c856832bfc6073b77535935ebe6ec224e7d51817e7aad8da30", size = 863054, upload-time = "2026-08-02T08:56:55.622Z" },
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.29.1" },
+    { name = "literalizer", specifier = "==2026.8.2" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.11" },


### PR DESCRIPTION
Bumps `literalizer` from 2026.7.29.1 to 2026.8.2 and refreshes the lockfile. Exposes upstream native multiline formats through `--string-format multiline` and adds `--multiline-raw-string-delimiter-base` for configuring C++ raw strings, with clean validation errors. Adds regression coverage, refreshes the help snapshot, and records the user-facing changes. Validated with the full 84-test suite at 100% coverage plus the pre-commit and pre-push lint and type-check hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump with additive CLI flags and error handling; behavior is covered by new tests and does not change auth or data paths.
> 
> **Overview**
> Bumps **`literalizer`** to **2026.8.2** (with lockfile refresh) and wires through upstream **multiline string** support: help now lists **`multiline`** under `--string-format`, and a new **`--multiline-raw-string-delimiter-base`** option passes a C++ fallback delimiter into the language constructor when the language defines that parameter.
> 
> CLI plumbing mirrors other language-specific string options (support gating, usage errors for non-C++ languages). **`InvalidCppRawStringDelimiterError`** from literalizer is caught alongside invalid record names and surfaced as **`ClickException`** messages instead of tracebacks.
> 
> Adds regression tests for multiline C++ output with a custom delimiter, invalid delimiter bases, and unsupported languages; updates the help snapshot, newsfragment, and spelling dict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3667f8cc80d3587d30eb9e9b05e6e76f12cf2ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->