### PR TITLE
Remove test defaults instead of suppressing them

### DIFF
--- a/tests/test_literalizer_cli.py
+++ b/tests/test_literalizer_cli.py
@@ -23,7 +23,7 @@ class ExceptionCase:
     input_string: str
     language: Any
     expected: str
-    variable_form: NewVariable | ExistingVariable | None = None  # noqa: NOD001
+    variable_form: NewVariable | ExistingVariable | None
 
 
 def test_help(file_regression: FileRegressionFixture) -> None:
@@ -462,6 +462,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
                 "Use empty_dict_key=R.EmptyDictKey.POSITIONAL to emit them "
                 "as unnamed list elements instead."
             ),
+            variable_form=None,
         ),
         ExceptionCase(
             input_format=InputFormat.JSON,
@@ -472,6 +473,7 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
                 "cannot be represented in the target language "
                 "(found types: int, str)"
             ),
+            variable_form=None,
         ),
         ExceptionCase(
             input_format=InputFormat.JSON,
@@ -482,12 +484,14 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
                 " (got 1 items, including null)."
                 " Use sequence_format=ARRAY instead."
             ),
+            variable_form=None,
         ),
         ExceptionCase(
             input_format=InputFormat.JSON,
             input_string='{"a": }\n',
             language=Python(),
             expected="Invalid JSON: Expecting value at line 1 column 7",
+            variable_form=None,
         ),
         ExceptionCase(
             input_format=InputFormat.YAML,
@@ -499,12 +503,14 @@ def test_invalid_yaml_is_shown_cleanly() -> None:
                 "did not find expected ',' or ']'\n"
                 '  in "<unicode string>", line 2, column 1'
             ),
+            variable_form=None,
         ),
         ExceptionCase(
             input_format=InputFormat.YAML,
             input_string="1: a\n2: b\n",
             language=Go(),
             expected="Go cannot represent dict key of type int",
+            variable_form=None,
         ),
     ],
     ids=(


### PR DESCRIPTION
Follow-up to the no-defaults rollout: `tests/` runs under `"all"` enforcement, so these defaults were carrying `# noqa: NOD001` rather than being addressed.

This removes the defaults for real and passes the values explicitly at the call sites that relied on them. No suppressions remain in `tests/`.

The removals were derived by diffing each signature against `HEAD` rather than by name matching, so only functions and dataclasses whose defaults actually changed had their call sites touched. `src/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only dataclass and fixture updates with no production code changes.
> 
> **Overview**
> Continues the **no-defaults** rollout in `tests/` by dropping the default on `ExceptionCase.variable_form` (previously `None` with `# noqa: NOD001`).
> 
> All six parametrized CLI exception cases now pass **`variable_form=None`** explicitly. Test structure only; no change to literalizer or CLI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f5994841f6125ca9e02c4d0e13f2ef4d59ea4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->