### PR TITLE
Lint reStructuredText prose with Vale to ban em dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ src/*/_setuptools_scm_version.py
 
 # Nix build output
 result
+
+# Vale styles downloaded by ``vale sync``
+styles/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -190,12 +190,15 @@ repos:
       # directory.
       # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
       # reStructuredText.
+      # ``vale sync`` also runs when ``.vale.ini`` changes, so a package
+      # bump takes effect without waiting for the next reStructuredText
+      # change.
       - id: vale-sync
         name: vale sync
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        types_or: [rst]
+        files: (\.rst$|^\.vale\.ini$)
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -183,6 +183,31 @@ repos:
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
+      # Vale enforces prose style rules, such as banning em dashes, in
+      # reStructuredText files.
+      # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
+      # which ``vale sync`` downloads into the (gitignored) ``styles``
+      # directory.
+      # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
+      # reStructuredText.
+      - id: vale-sync
+        name: vale sync
+        entry: uv run --extra=dev vale sync
+        language: python
+        pass_filenames: false
+        types_or: [rst]
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+
+      - id: vale
+        name: vale
+        entry: uv run --extra=dev vale
+        language: python
+        types_or: [rst]
+        require_serial: true
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = error
+
+Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+
+[*.rst]
+BasedOnStyles = ClearProse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ optional-dependencies.dev = [
     "towncrier==25.8.0",
     "ty==0.0.65",
     "uv==0.12.1",
+    "vale==3.13.0.0",
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",
@@ -270,6 +271,7 @@ omit-covered-files = true
 ignore = [
     ".pre-commit-config.yaml",
     ".prettierrc",
+    ".vale.ini",
     ".vscode/**",
     "admin",
     "admin/**",

--- a/uv.lock
+++ b/uv.lock
@@ -691,6 +691,7 @@ dev = [
     { name = "towncrier" },
     { name = "ty" },
     { name = "uv" },
+    { name = "vale" },
     { name = "vulture" },
     { name = "yamlfix" },
     { name = "zizmor" },
@@ -748,6 +749,7 @@ requires-dist = [
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.65" },
     { name = "uv", marker = "extra == 'dev'", specifier = "==0.12.1" },
+    { name = "vale", marker = "extra == 'dev'", specifier = "==3.13.0.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.29.0" },
@@ -2284,6 +2286,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/02/f73e4867c0748eaa3dea90cdfeb73d15bab0f04802c5c20bb37fc14918fe/uv-0.12.1-py3-none-win32.whl", hash = "sha256:173ee216f17d89fc39f65339d311a53584fc7de4918d27c0f3c7edafabc6b54d", size = 19440400, upload-time = "2026-07-31T19:42:25.788Z" },
     { url = "https://files.pythonhosted.org/packages/0d/a4/467c99c76fefa8b1259a1d382a5e49f73068f38a2d58db401504a783ed2c/uv-0.12.1-py3-none-win_amd64.whl", hash = "sha256:bd02f2da212e6a983115dc64a6fc94e9256c2d60e056d6b669de0a6025aaec05", size = 20277937, upload-time = "2026-07-31T19:42:29.375Z" },
     { url = "https://files.pythonhosted.org/packages/68/80/ec1acbf8e22dc4866f9070c30b064728cc0da73bedc30f2fbfdc0c5901a7/uv-0.12.1-py3-none-win_arm64.whl", hash = "sha256:ead7ad064f291a5df358c3ffa8ffab347a32bd5a75a6a068ca22254c2539a829", size = 19258877, upload-time = "2026-07-31T19:42:32.544Z" },
+]
+
+[[package]]
+name = "vale"
+version = "3.13.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0d/6ebd7d020135888cc4d35290737871986ceabf176ba5e44827294429283a/vale-3.13.0.0.tar.gz", hash = "sha256:9c2482ecab515e58aa8d7e1a09f3d44ed674a07502786e22ff60c9d4fdc8493b", size = 5340, upload-time = "2025-10-28T13:20:41.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/05/92b9e4d3e3cb424d2a1aa6e070ee838f15f6739a90b06964156a24fe49ce/vale-3.13.0.0-py3-none-any.whl", hash = "sha256:b565197a5f6e430af7ccc59204e75c6067bbd091a0073d700efdd0fba21873ed", size = 5944, upload-time = "2025-10-28T13:20:40.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds Vale as a pre-commit hook so em dashes cannot creep into our reStructuredText.

The rules come from the pinned [ClearProse](https://github.com/adamtheturtle/vale-style-clear-prose) style package (v1.1.0) rather than a hand-written local rule, configured in a new `.vale.ini`; `vale sync` downloads it into a gitignored `styles/` directory before the lint runs. That release ships as a Vale config package, so it carries the `TokenIgnores` pattern that keeps Sphinx role targets such as `:ref:` out of the prose check. `vale==3.13.0.0` is pinned in the dev extra, and `.vale.ini` is added to the `check-manifest` ignores.

Verified locally: `vale` reports no alerts across the tracked `.rst` files, and `prek run` over the changed files passes.

Note that the `vale` PyPI wrapper is behind the upstream binary (3.13.0 against 3.17.1), and 3.13.0 drops the occasional alert: on the ClearProse fixture with seven em dashes it reports six, where 3.17.1 reports all seven. The ban still holds, because a file with an em dash is still reported, but the pin is worth bumping when the wrapper publishes a newer Vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling and documentation lint only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Vale** prose linting for reStructuredText in pre-commit, using the pinned **ClearProse** style (notably banning em dashes).
> 
> A new **`.vale.ini`** points at the ClearProse package; **`vale sync`** (also triggered when `.vale.ini` changes) downloads styles into a gitignored **`styles/`** directory before the **`vale`** hook runs on `.rst` files. **`vale==3.13.0.0`** is added to the dev extra and lockfile; **`.vale.ini`** is excluded from **`check-manifest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f212faad21649c133499915dca882ff48f1feb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->